### PR TITLE
Use abi files with mandatory address provision

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,20 @@ from squid_py.ocean_contracts import OceanContractsWrapper
 ocean = OceanContractsWrapper(host='http://localhost', port=8545, config_path='config.ini')    
 ocean.init_contracts()
 ```
-If you do not pass the config_path you can pass using $CONFIG_FILE environment variable.
+
+If you do not pass the config_path you can pass using **$CONFIG_FILE** environment variable.
+
+It is possible do not pass the config file, but you should be sure of provide the host, port and addresses.
+If you opt for this you can pass the addresses using the following environment variables:
+
+
+- **MARKET_ADDRESS**  Address of your market contract deployed in the network
+- **AUTH_ADDRESS**    Address of your auth contract deployed in the network.
+- **TOKEN_ADDRESS**   Address of your token contract deployed in the network.
+- **KEEPER_HOST**     You can pass the host of your keeper instead of call it explicitly in class.
+- **KEEPER_PORT**     You can pass the port of your keeper instead of call it explicitly in class.
+
+
 After that you have to init the contracts. And you can start to use the methods in the different contracts.
 
 You will find as well two methods that allow you to register and consume an asset.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ from squid_py.ocean_contracts import OceanContractsWrapper
 ocean = OceanContractsWrapper(host='http://localhost', port=8545, config_path='config.ini')    
 ocean.init_contracts()
 ```
-If you do not pass the config_path the wrapper will use the default values. 
+If you do not pass the config_path you can pass using $CONFIG_FILE environment variable.
 After that you have to init the contracts. And you can start to use the methods in the different contracts.
 
 You will find as well two methods that allow you to register and consume an asset.
@@ -74,6 +74,19 @@ consume(resource=resouce_id,
         provider_account=ocean.web3.eth.accounts[0],
         ocean_contracts_wrapper=ocean,
         json_metadata=json_request_consume)
+
+```
+
+## Configuration
+
+```yaml
+[keeper-contracts]
+market.address = # Address of your market contract deployed in the network. [Mandatory]
+auth.address = # Address of your auth contract deployed in the network. [Mandatory]
+token.address = # Address of your token contract deployed in the network. [Mandatory]
+keeper.host = # You can pass the host of your keeper instead of call it explicitly in class.
+keeper.port = 8545  # You can pass the port of your keeper instead of call it explicitly in class.
+contracts.folder =  # You can pass the directory of your contracts instead of use the library.
 
 ```
 

--- a/config.ini
+++ b/config.ini
@@ -1,7 +1,4 @@
 [keeper-contracts]
-;keeper.host = http://localhost
-;keeper.port = 8545
-;contracts.folder = venv/contracts
 market.address =
 auth.address =
 token.address =

--- a/environment.yml
+++ b/environment.yml
@@ -48,7 +48,7 @@ dependencies:
     - flake8==3.5.0
     - hexbytes==0.1.0
     - idna==2.7
-    - keeper-contracts==0.0.1.5
+    - keeper-contracts==0.1.1
     - lru-dict==1.1.6
     - mccabe==0.6.1
     - more-itertools==4.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -26,7 +26,7 @@ flake8==3.5.0
 hexbytes==0.1.0
 humanfriendly==4.16.1
 idna==2.7
-keeper-contracts==0.0.1.5
+keeper-contracts==0.1.1
 lru-dict==1.1.6
 mccabe==0.6.1
 more-itertools==4.3.0

--- a/squid_py/config_parser.py
+++ b/squid_py/config_parser.py
@@ -1,6 +1,7 @@
 import os
 import site
 import configparser
+import logging
 
 
 def load_config_section(file_path, section):
@@ -8,9 +9,9 @@ def load_config_section(file_path, section):
         assert file_path and os.path.exists(file_path), 'config file_path is required.'
         config = parse_config(file_path, section)
         return config
-    except Exception as err:
-        # TODO: replace Exception with custom error class
-        raise Exception("You should provide a valid config: %s" % str(err))
+    except Exception:
+        logging.warning("You are not providing a valid configuration.")
+        return None
 
 
 def parse_config(file_path, section):
@@ -23,10 +24,10 @@ def parse_config(file_path, section):
         try:
             config_dict[option] = config_parser.get(section, option)
             if config_dict[option] == -1:
-                print("skip: %s" % option)
+                logging.info("skip: %s" % option)
         except Exception as err:
-            print("error on %s!" % option)
-            print("exception on %s" % str(err))
+            logging.error("error on %s!" % option)
+            logging.error("exception on %s" % str(err))
             config_dict[option] = None
     return config_dict
 

--- a/squid_py/constants.py
+++ b/squid_py/constants.py
@@ -1,9 +1,4 @@
-class OceanContracts:
-    OCEAN_MARKET_CONTRACT = 'OceanMarket'
-    OCEAN_TOKEN_CONTRACT = 'OceanToken'
-    OCEAN_ACL_CONTRACT = 'OceanAuth'
-
-    OMKT = OCEAN_MARKET_CONTRACT
-    OTKN = OCEAN_TOKEN_CONTRACT
-    OACL = OCEAN_ACL_CONTRACT
-    KEEPER_CONTRACTS = 'keeper-contracts'
+OCEAN_MARKET_CONTRACT = 'OceanMarket'
+OCEAN_TOKEN_CONTRACT = 'OceanToken'
+OCEAN_ACL_CONTRACT = 'OceanAuth'
+KEEPER_CONTRACTS = 'keeper-contracts'

--- a/squid_py/consumer.py
+++ b/squid_py/consumer.py
@@ -34,7 +34,6 @@ def register(publisher_account, provider_account, price, ocean_contracts_wrapper
     provider_account = provider_account
     print("publisher: %s" % publisher_account)
     print("provider: %s" % provider_account)
-
     resource_id = market_concise.generateId('resource', transact={'from': provider_account})
     print("recource_id: %s" % resource_id)
     resource_price = price

--- a/squid_py/consumer.py
+++ b/squid_py/consumer.py
@@ -1,6 +1,5 @@
 import time
-
-from squid_py.constants import OceanContracts
+from squid_py.constants import OCEAN_MARKET_CONTRACT, OCEAN_ACL_CONTRACT, OCEAN_TOKEN_CONTRACT
 from squid_py.acl import generate_encryption_keys, decrypt, decode
 from eth_account.messages import defunct_hash_message
 import json
@@ -29,7 +28,7 @@ def register(publisher_account, provider_account, price, ocean_contracts_wrapper
              provider_host='http://localhost:5000'):
     if not bool(ocean_contracts_wrapper.contracts):
         ocean_contracts_wrapper.init_contracts()
-    market_concise = ocean_contracts_wrapper.contracts[OceanContracts.OMKT][0]
+    market_concise = ocean_contracts_wrapper.contracts[OCEAN_MARKET_CONTRACT][0]
     publisher_account = publisher_account
     provider_account = provider_account
     print("publisher: %s" % publisher_account)
@@ -53,10 +52,10 @@ def register(publisher_account, provider_account, price, ocean_contracts_wrapper
 def consume(resource, consumer_account, provider_account, ocean_contracts_wrapper):
     if not bool(ocean_contracts_wrapper.contracts):
         ocean_contracts_wrapper.init_contracts()
-    market_concise = ocean_contracts_wrapper.contracts[OceanContracts.OMKT][0]
-    acl_concise = ocean_contracts_wrapper.contracts[OceanContracts.OACL][0]
-    acl = ocean_contracts_wrapper.contracts[OceanContracts.OACL][1]
-    token_concise = ocean_contracts_wrapper.contracts[OceanContracts.OTKN][0]
+    market_concise = ocean_contracts_wrapper.contracts[OCEAN_MARKET_CONTRACT][0]
+    acl_concise = ocean_contracts_wrapper.contracts[OCEAN_ACL_CONTRACT][0]
+    acl = ocean_contracts_wrapper.contracts[OCEAN_ACL_CONTRACT][1]
+    token_concise = ocean_contracts_wrapper.contracts[OCEAN_TOKEN_CONTRACT][0]
 
     expire_seconds = 9999999999
     consumer_account = consumer_account

--- a/squid_py/ocean_contracts.py
+++ b/squid_py/ocean_contracts.py
@@ -1,62 +1,48 @@
-import os, json, time
+import json
+import logging
+import os
+import time
+from collections import namedtuple
+from threading import Thread
 from web3 import Web3, HTTPProvider
 from web3.contract import ConciseContract
-from threading import Thread
-from collections import namedtuple
 from squid_py.config_parser import load_config_section, get_contracts_path
 from squid_py.constants import OceanContracts
-
 from squid_py.log import setup_logging
-import logging
+
 setup_logging()
-
-
 Signature = namedtuple('Signature', ('v', 'r', 's'))
-
-
-def convert_to_bytes(data):
-    return Web3.toBytes(text=data)
-
-def convert_to_string(data):
-    return Web3.toHex(data)
-
-def convert_to_text(data):
-    return Web3.toText(data)
 
 
 class OceanContractsWrapper(object):
 
     def __init__(self, host=None, port=None, config_path=None):
-
         try:
             config_path = os.getenv('CONFIG_FILE') if not config_path else config_path
             self.config = load_config_section(config_path, OceanContracts.KEEPER_CONTRACTS)
+            logging.info("Configuration loaded from {}".format(config_path))
         except Exception:
-            self.config = None
-        logging.info("Configuration loaded from {}".format(config_path))
+            logging.error('Provide the path of your config path. You can specify the path in $CONFIG_FILE environment '
+                          'variable.')
+            raise Exception('You should provide a valid config file.')
 
         self.host = self.get_value('keeper.host', 'KEEPER_HOST', host)
         self.port = self.get_value('keeper.port', 'KEEPER_PORT', port)
-        self.web3 = OceanContractsWrapper.connect_web3(self.host, self.port)
-        logging.info("web3 connection: {}".format(self.web3))
-
-        self.account = self.get_value('provider.account', 'PROVIDER_ACCOUNT', self.web3.eth.accounts[0])
-        self.contracts_abis_path = get_contracts_path(self.config)
-        self.contracts = {}
         self.default_contract_address_map = {
             OceanContracts.OMKT: self.get_value('market.address', 'MARKET_ADDRESS', None),
             OceanContracts.OACL: self.get_value('auth.address', 'AUTH_ADDRESS', None),
             OceanContracts.OTKN: self.get_value('token.address', 'TOKEN_ADDRESS', None)
         }
-        self.network = self.get_value('keeper.network', 'KEEPER_NETWORK', 'development')
+        self.web3 = OceanContractsWrapper.connect_web3(self.host, self.port)
+        logging.info("web3 connection: {}".format(self.web3))
+        self.account = self.get_value('provider.account', 'PROVIDER_ACCOUNT', self.web3.eth.accounts[0])
+        self.contracts_abis_path = get_contracts_path(self.config)
+        self.contracts = {}
 
-        logging.info("New Ocean Contracts Wrapper, hosted at {}:{}".format(self.host,self.port))
+        logging.info("New Ocean Contracts Wrapper, hosted at {}:{}".format(self.host, self.port))
         logging.info("OceanContracts.OMKT : {}".format(self.default_contract_address_map[OceanContracts.OMKT]))
         logging.info("OceanContracts.OACL : {}".format(self.default_contract_address_map[OceanContracts.OACL]))
         logging.info("OceanContracts.OTKN : {}".format(self.default_contract_address_map[OceanContracts.OTKN]))
-
-        #self.default_contract_address_map
-
 
     def get_value(self, value, env_var, default):
         if os.getenv(env_var) is not None:
@@ -67,22 +53,22 @@ class OceanContractsWrapper(object):
             return default
 
     def init_contracts(self, contracts_folder=None, contracts_addresses=None):
+        """Initialize the contracts connection."""
         contracts_abis_path = contracts_folder if contracts_folder else self.contracts_abis_path
         contract_address_map = contracts_addresses if contracts_addresses else self.default_contract_address_map
         for contract_name, address in contract_address_map.items():
-            contract_abi_file = os.path.join(contracts_abis_path, contract_name + '.' + self.network + '.json')
+            contract_abi_file = os.path.join(contracts_abis_path, contract_name + '.json')
             self.contracts[contract_name] = self.get_contract_instances(contract_abi_file, address)
 
     @staticmethod
     def connect_web3(host, port='8545'):
+        """Establish a connexion using Web3 with the client."""
         return Web3(HTTPProvider("%s:%s" % (host, port)))
 
     def get_contract_instances(self, contract_file, contract_address):
+        """Retrieve a tuple with the concise contract and the contract definition."""
         with open(contract_file, 'r') as abi_definition:
             abi = json.load(abi_definition)
-            if not contract_address and 'address' in abi:
-                contract_address = abi['address']
-                print('Extracted %s contract address ' % contract_file, contract_address)
             concise_cont = self.web3.eth.contract(
                 address=self.web3.toChecksumAddress(contract_address),
                 abi=abi['abi'],
@@ -143,3 +129,15 @@ class OceanContractsWrapper(object):
         if v != 27 and v != 28:
             v = 27 + v % 2
         return Signature(v, r, s)
+
+
+def convert_to_bytes(data):
+    return Web3.toBytes(text=data)
+
+
+def convert_to_string(data):
+    return Web3.toHex(data)
+
+
+def convert_to_text(data):
+    return Web3.toText(data)

--- a/squid_py/ocean_contracts.py
+++ b/squid_py/ocean_contracts.py
@@ -7,44 +7,42 @@ from threading import Thread
 from web3 import Web3, HTTPProvider
 from web3.contract import ConciseContract
 from squid_py.config_parser import load_config_section, get_contracts_path
-from squid_py.constants import OceanContracts
+from squid_py.constants import OCEAN_TOKEN_CONTRACT,OCEAN_ACL_CONTRACT,OCEAN_MARKET_CONTRACT,KEEPER_CONTRACTS
 from squid_py.log import setup_logging
 
 setup_logging()
 Signature = namedtuple('Signature', ('v', 'r', 's'))
 
 
-class OceanContractsWrapper(object):
+class OceanContracts(object):
 
     def __init__(self, host=None, port=None, config_path=None):
         try:
             config_path = os.getenv('CONFIG_FILE') if not config_path else config_path
-            self.config = load_config_section(config_path, OceanContracts.KEEPER_CONTRACTS)
-            logging.info("Configuration loaded from {}".format(config_path))
+            self.config = load_config_section(config_path, KEEPER_CONTRACTS)
+            self.host = self.get_value('keeper.host', 'KEEPER_HOST', host)
+            self.port = self.get_value('keeper.port', 'KEEPER_PORT', port)
+            self.default_contract_address_map = {
+                OCEAN_MARKET_CONTRACT: self.get_value('market.address', 'MARKET_ADDRESS', None),
+                OCEAN_ACL_CONTRACT: self.get_value('auth.address', 'AUTH_ADDRESS', None),
+                OCEAN_TOKEN_CONTRACT: self.get_value('token.address', 'TOKEN_ADDRESS', None)
+            }
+            self.web3 = OceanContracts.connect_web3(self.host, self.port)
+            logging.info("web3 connection: {}".format(self.web3))
+            self.account = self.get_value('provider.account', 'PROVIDER_ACCOUNT', self.web3.eth.accounts[0])
+            self.contracts_abis_path = get_contracts_path(self.config)
+            self.contracts = {}
+            logging.info("New Ocean Contracts Wrapper, hosted at {}:{}".format(self.host, self.port))
+            logging.info("OceanMarket : {}".format(self.default_contract_address_map[OCEAN_MARKET_CONTRACT]))
+            logging.info("OceanAuth : {}".format(self.default_contract_address_map[OCEAN_ACL_CONTRACT]))
+            logging.info("OceanToken : {}".format(self.default_contract_address_map[OCEAN_TOKEN_CONTRACT]))
         except Exception:
-            logging.error('Provide the path of your config path. You can specify the path in $CONFIG_FILE environment '
+            logging.error('OceanContracts could not initiate. You can specify the path in $CONFIG_FILE environment '
                           'variable.')
             raise Exception('You should provide a valid config file.')
 
-        self.host = self.get_value('keeper.host', 'KEEPER_HOST', host)
-        self.port = self.get_value('keeper.port', 'KEEPER_PORT', port)
-        self.default_contract_address_map = {
-            OceanContracts.OMKT: self.get_value('market.address', 'MARKET_ADDRESS', None),
-            OceanContracts.OACL: self.get_value('auth.address', 'AUTH_ADDRESS', None),
-            OceanContracts.OTKN: self.get_value('token.address', 'TOKEN_ADDRESS', None)
-        }
-        self.web3 = OceanContractsWrapper.connect_web3(self.host, self.port)
-        logging.info("web3 connection: {}".format(self.web3))
-        self.account = self.get_value('provider.account', 'PROVIDER_ACCOUNT', self.web3.eth.accounts[0])
-        self.contracts_abis_path = get_contracts_path(self.config)
-        self.contracts = {}
-
-        logging.info("New Ocean Contracts Wrapper, hosted at {}:{}".format(self.host, self.port))
-        logging.info("OceanContracts.OMKT : {}".format(self.default_contract_address_map[OceanContracts.OMKT]))
-        logging.info("OceanContracts.OACL : {}".format(self.default_contract_address_map[OceanContracts.OACL]))
-        logging.info("OceanContracts.OTKN : {}".format(self.default_contract_address_map[OceanContracts.OTKN]))
-
     def get_value(self, value, env_var, default):
+        """Helper to get the values from the environment."""
         if os.getenv(env_var) is not None:
             return os.getenv(env_var)
         elif self.config is not None and value in self.config:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,5 +1,5 @@
 from squid_py.consumer import register
-from squid_py.ocean_contracts import OceanContractsWrapper
+from squid_py.ocean_contracts import OceanContracts
 import requests
 
 json_consume = {"publisherId": "0x01",
@@ -20,7 +20,7 @@ json_request_consume = {
 
 
 def test_register_consume():
-    ocean = OceanContractsWrapper(host='http://0.0.0.0', port=8545, config_path='config_local.ini')
+    ocean = OceanContracts(host='http://0.0.0.0', port=8545)
     resouce_id = register(publisher_account=ocean.web3.eth.accounts[1],
                           provider_account=ocean.web3.eth.accounts[0],
                           price=10,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -20,7 +20,7 @@ json_request_consume = {
 
 
 def test_register_consume():
-    ocean = OceanContractsWrapper(host='http://0.0.0.0', port=8545)
+    ocean = OceanContractsWrapper(host='http://0.0.0.0', port=8545, config_path='config_local.ini')
     resouce_id = register(publisher_account=ocean.web3.eth.accounts[1],
                           provider_account=ocean.web3.eth.accounts[0],
                           price=10,

--- a/tests/test_ocean_contracts.py
+++ b/tests/test_ocean_contracts.py
@@ -2,9 +2,14 @@ from squid_py.ocean_contracts import OceanContractsWrapper, convert_to_bytes, co
 from squid_py.config_parser import load_config_section
 from squid_py.constants import OceanContracts
 import logging
+import os
+
 
 def test_ocean_contracts():
-    ocean = OceanContractsWrapper(host='http://0.0.0.0', port=8545)
+    os.environ['CONFIG_FILE'] = 'config_local.ini'
+    os.environ['KEEPER_HOST'] = 'http://0.0.0.0'
+    os.environ['KEEPER_PORT'] = '8545'
+    ocean = OceanContractsWrapper()
     ocean.init_contracts()
     assert ocean.contracts is not None
 
@@ -25,6 +30,7 @@ def test_split_signature():
     assert split_signature.v == 28
     assert split_signature.r == b'\x19\x15!\xecwnX1o/\xdeho\x9a9\xdd9^\xbb\x8c2z\x88!\x95\xdc=\xe6\xafc\x0f\xe9'
     assert split_signature.s == b'\x14\x12\xc6\xde\x0b\n\xa6\x11\xc0\x1cvv\x9f\x99O8\x15\xf6f\xe7\xab\xea\x982Ds\x0bX\xd9\x94\xa42'
+
 
 def test_convert():
     input_text = "my text"

--- a/tests/test_ocean_contracts.py
+++ b/tests/test_ocean_contracts.py
@@ -1,6 +1,6 @@
-from squid_py.ocean_contracts import OceanContractsWrapper, convert_to_bytes, convert_to_string, convert_to_text
+from squid_py.ocean_contracts import OceanContracts, convert_to_bytes, convert_to_string, convert_to_text
 from squid_py.config_parser import load_config_section
-from squid_py.constants import OceanContracts
+from squid_py.constants import KEEPER_CONTRACTS, OCEAN_MARKET_CONTRACT
 import logging
 import os
 
@@ -9,7 +9,7 @@ def test_ocean_contracts():
     os.environ['CONFIG_FILE'] = 'config_local.ini'
     os.environ['KEEPER_HOST'] = 'http://0.0.0.0'
     os.environ['KEEPER_PORT'] = '8545'
-    ocean = OceanContractsWrapper()
+    ocean = OceanContracts()
     ocean.init_contracts()
     assert ocean.contracts is not None
 
@@ -17,14 +17,14 @@ def test_ocean_contracts():
 def test_ocean_contracts_with_conf(caplog):
     caplog.set_level(logging.DEBUG)
     # Need to ensure config.ini is populated!
-    ocean = OceanContractsWrapper(host='http://0.0.0.0', port=8545, config_path='config_local.ini')
+    ocean = OceanContracts(host='http://0.0.0.0', port=8545, config_path='config_local.ini')
     ocean.init_contracts()
-    conf = load_config_section('config_local.ini', OceanContracts.KEEPER_CONTRACTS)
-    assert ocean.contracts[OceanContracts.OMKT][0].address == ocean.web3.toChecksumAddress(conf['market.address'])
+    conf = load_config_section('config_local.ini', KEEPER_CONTRACTS)
+    assert ocean.contracts[OCEAN_MARKET_CONTRACT][0].address == ocean.web3.toChecksumAddress(conf['market.address'])
 
 
 def test_split_signature():
-    ocean = OceanContractsWrapper(host='http://0.0.0.0', port=8545)
+    ocean = OceanContracts(host='http://0.0.0.0', port=8545)
     signature = b'\x19\x15!\xecwnX1o/\xdeho\x9a9\xdd9^\xbb\x8c2z\x88!\x95\xdc=\xe6\xafc\x0f\xe9\x14\x12\xc6\xde\x0b\n\xa6\x11\xc0\x1cvv\x9f\x99O8\x15\xf6f\xe7\xab\xea\x982Ds\x0bX\xd9\x94\xa42\x01'
     split_signature = ocean.split_signature(signature=signature)
     assert split_signature.v == 28


### PR DESCRIPTION
## Description
Go back to use abi files instead of the files with the address included to be consistent.
Now you should be sure to retrieve the address of the contract deployed and pass in the config file or as environment variable.
## Is this PR related with an open issue?
#15 
https://github.com/oceanprotocol/provider/issues/56

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->](https://media.giphy.com/media/t3Mzdx0SA3Eis/giphy.gif)