### PR TITLE
Wait for the contracts to be migrated, before acquiring the addresses

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -12,6 +12,10 @@ cp $CONF_TEMPLATE $CONF_FILE
 #KEEPERDIR=~/Projects/keeper-contracts
 #cd $KEEPERDIR
 
+# wait for docker to compile and install the contracts
+echo "Waiting for keeper-contracts to be installed"
+docker exec -it docker_keeper-contracts_1 bash -c 'while [ ! -f /keeper-contracts/artifacts/ready ]; do sleep 1; done'
+
 market=$(docker exec -it docker_keeper-contracts_1 python -c "import sys, json; print(json.load(open('/keeper-contracts/artifacts/OceanMarket.development.json', 'r'))['address'])")
 token=$(docker exec -it docker_keeper-contracts_1 python -c "import sys, json; print(json.load(open('/keeper-contracts/artifacts/OceanToken.development.json', 'r'))['address'])")
 auth=$(docker exec -it docker_keeper-contracts_1 python -c "import sys, json; print(json.load(open('/keeper-contracts/artifacts/OceanAuth.development.json', 'r'))['address'])")


### PR DESCRIPTION
## Description
Because the migration process for the keeper-contracts takes a while, and the OceanAuth contract is one of the last to migrate. The current travis test fails because the OceanAuth artifact file cannot be found and returns an empty address.

I have placed a 'wait' process at the begining of ```deploy``` script to wait for the ```/keeper-contracts/artifacts/ready``` file to be available.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
