### PR TITLE
Use docker volume instead of absolute path

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       REUSE_DATABASE: "false"
       NETWORK_NAME: "ganache"
     volumes:
-    - /artifacts:/keeper-contracts/artifacts/
+    - artifacts:/keeper-contracts/artifacts/
 
   provider:
     image: oceanprotocol/provider:develop
@@ -39,7 +39,10 @@ services:
       DB_HOSTNAME: mongodb
       LOCAL_CONTRACTS: 'true'
     volumes:
-    - /artifacts:/usr/local/keeper-contracts/:ro
+    - artifacts:/usr/local/keeper-contracts/:ro
 
 networks:
   backend:
+
+volumes:
+  artifacts:


### PR DESCRIPTION
## Description

Avoid using an absolute path for volumes (thus we keep our host systems cleaner).

## Is this PR related with an open issue?

No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()