### PR TITLE
Feature/add didresolve information

### DIFF
--- a/squid_py/didresolver.py
+++ b/squid_py/didresolver.py
@@ -42,7 +42,7 @@ class DIDResolved():
     def __init__(self):
         self._items = []
         self._value = None
-        
+
     def add_data(self, data, value):
         """
         Add a resolved event data item to the list of resolved items
@@ -57,8 +57,8 @@ class DIDResolved():
             self._value = did_generate_from_id(value)
         else:
             self._value = value
-        
-    
+
+
     @property
     def did_bytes(self):
         if self.self._items:
@@ -73,14 +73,20 @@ class DIDResolved():
     def key(self):
         if self._items:
             return self._items[-1]['key']
-            
+
+    @property
+    def block_number(self):
+        print(self._items)
+        if self._items:
+            return self._items[-1]['block_number']
+
     @property
     def value(self):
         return self._value
-        
+
     @property
     def value_type(self):
-        if self._data:
+        if self._items:
             return self._items[-1]['value_type']
 
     @property
@@ -92,7 +98,7 @@ class DIDResolved():
         if self.is_url:
             return self._value
         return None
-        
+
     @property
     def is_ddo(self):
         return self._items and self._items[-1]['value_type'] == VALUE_TYPE_DDO
@@ -116,14 +122,14 @@ class DIDResolved():
     @property
     def items(self):
         return self._items
-    
+
     @property
     def hop_count(self):
         if self._items:
             return len(self._items)
         return 0
-        
-        
+
+
 class DIDResolver():
     """
     DID Resolver class
@@ -206,7 +212,7 @@ class DIDResolver():
                     raise OceanDIDCircularReference('circular reference found at did {}'.format(Web3.toHex(did_bytes)))
                 data = self.get_did(did_bytes)
 
-            
+
         if resolved.hop_count > 0:
             return resolved
         return None

--- a/squid_py/didresolver.py
+++ b/squid_py/didresolver.py
@@ -66,12 +66,12 @@ class DIDResolved():
 
     @property
     def owner(self):
-        if self.self._items:
+        if self._items:
             return self._items[-1]['owner']
 
     @property
     def key(self):
-        if self.self._items:
+        if self._items:
             return self._items[-1]['key']
             
     @property
@@ -218,7 +218,7 @@ class DIDResolver():
         result = None
 
         block_number = self._didregistry.get_update_at(did_bytes)
-
+        logger.debug('block_number %d', block_number)
         if block_number == 0:
             raise OceanDIDNotFound('cannot find DID {}'.format(Web3.toHex(did_bytes)))
 
@@ -232,12 +232,14 @@ class DIDResolver():
             log_item = log_items[len(log_items) - 1]
             value, value_type, block_number = decode_single('(string,uint8,uint256)', \
                 Web3.toBytes(hexstr=log_item['data']))
+            topics = log_item['topics']
+            logger.debug('topics {}'.format(topics))
             result = {
                 'value_type': value_type,
                 'value': value,
                 'block_number': block_number,
-                'did_bytes': log_item['topics'][1],
-                'owner': log_item['topics'][2],
-                'key': log_item['topics'][2],
+                'did_bytes': Web3.toBytes(topics[1]),
+                'owner': Web3.toChecksumAddress(topics[2][-20:]),
+                'key': Web3.toBytes(topics[3]),
             }
         return result

--- a/squid_py/didresolver.py
+++ b/squid_py/didresolver.py
@@ -40,6 +40,7 @@ class DIDResolved():
     Class that handles the resolved DID information
     """
     def __init__(self):
+        """init the object with an empty set of hops"""
         self._items = []
         self._value = None
 
@@ -61,70 +62,89 @@ class DIDResolved():
 
     @property
     def did_bytes(self):
-        if self.self._items:
+        """return the resolved did in bytes"""
+        if self._items:
             return self._items[-1]['did_bytes']
+        return None
 
     @property
     def owner(self):
+        """return the resolved owner address"""
         if self._items:
             return self._items[-1]['owner']
+        return None
 
     @property
     def key(self):
+        """return the resolved key"""
         if self._items:
             return self._items[-1]['key']
+        return None
 
     @property
     def block_number(self):
-        print(self._items)
+        """return the resolved block number"""
         if self._items:
             return self._items[-1]['block_number']
+        return None
 
     @property
     def value(self):
+        """return the resolved value can be a URL/DDO(on chain)/DID(string)"""
         return self._value
 
     @property
     def value_type(self):
+        """return the resolved value type"""
         if self._items:
             return self._items[-1]['value_type']
+        return None
 
     @property
     def is_url(self):
+        """return True if the resolved value is an URL"""
         return self._items and self._items[-1]['value_type'] == VALUE_TYPE_URL
 
     @property
     def url(self):
+        """return the resolved URL"""
         if self.is_url:
             return self._value
         return None
 
     @property
     def is_ddo(self):
+        """return True if the resolved value is a DDO JSON string"""
         return self._items and self._items[-1]['value_type'] == VALUE_TYPE_DDO
 
     @property
     def ddo(self):
+        """return the resolved DDO JSON string"""
         if self.is_ddo:
             return self._value
         return None
 
     @property
     def is_did(self):
+        """return True if the resolved value is a DID"""
         return self._items and self._items[-1]['value_type'] == VALUE_TYPE_DID
 
     @property
     def did(self):
+        """return the resolved DID value as a string"""
         if self.is_did:
             return self._value
         return None
 
     @property
     def items(self):
+        """return the list of DIDRegistry items used to get to this resolved value
+        the last item is the resolved item"""
         return self._items
 
     @property
     def hop_count(self):
+        """return the number of hops needed to resolve the DID"""
         if self._items:
             return len(self._items)
         return 0
@@ -234,8 +254,8 @@ class DIDResolver():
             'topics': [self._event_signature, Web3.toHex(did_bytes)]
         })
         log_items = block_filter.get_all_entries()
-        if log_items and len(log_items) > 0:
-            log_item = log_items[len(log_items) - 1]
+        if log_items:
+            log_item = log_items[-1]
             value, value_type, block_number = decode_single('(string,uint8,uint256)', \
                 Web3.toBytes(hexstr=log_item['data']))
             topics = log_item['topics']

--- a/squid_py/didresolver.py
+++ b/squid_py/didresolver.py
@@ -18,7 +18,10 @@ from squid_py.exceptions import (
     OceanDIDUnknownValueType
 )
 
-from squid_py.did import did_to_id_bytes
+from squid_py.did import (
+    did_to_id_bytes,
+    did_generate_from_id
+)
 
 
 
@@ -32,6 +35,95 @@ VALUE_TYPE_DDO = 3
 
 logger = logging.getLogger()
 
+class DIDResolved():
+    """
+    Class that handles the resolved DID information
+    """
+    def __init__(self):
+        self._items = []
+        self._value = None
+        
+    def add_data(self, data, value):
+        """
+        Add a resolved event data item to the list of resolved items
+        as this could be the last item in the chain.
+
+        :param data: dictionary of the DIDRegistry event data
+        :param value: formated value depending on the data['value_type'] string, bytes32
+
+        """
+        self._items.append(data)
+        if data['value_type'] == VALUE_TYPE_DID:
+            self._value = did_generate_from_id(value)
+        else:
+            self._value = value
+        
+    
+    @property
+    def did_bytes(self):
+        if self.self._items:
+            return self._items[-1]['did_bytes']
+
+    @property
+    def owner(self):
+        if self.self._items:
+            return self._items[-1]['owner']
+
+    @property
+    def key(self):
+        if self.self._items:
+            return self._items[-1]['key']
+            
+    @property
+    def value(self):
+        return self._value
+        
+    @property
+    def value_type(self):
+        if self._data:
+            return self._items[-1]['value_type']
+
+    @property
+    def is_url(self):
+        return self._items and self._items[-1]['value_type'] == VALUE_TYPE_URL
+
+    @property
+    def url(self):
+        if self.is_url:
+            return self._value
+        return None
+        
+    @property
+    def is_ddo(self):
+        return self._items and self._items[-1]['value_type'] == VALUE_TYPE_DDO
+
+    @property
+    def ddo(self):
+        if self.is_ddo:
+            return self._value
+        return None
+
+    @property
+    def is_did(self):
+        return self._items and self._items[-1]['value_type'] == VALUE_TYPE_DID
+
+    @property
+    def did(self):
+        if self.is_did:
+            return self._value
+        return None
+
+    @property
+    def items(self):
+        return self._items
+    
+    @property
+    def hop_count(self):
+        if self._items:
+            return len(self._items)
+        return 0
+        
+        
 class DIDResolver():
     """
     DID Resolver class
@@ -69,6 +161,7 @@ class DIDResolver():
         if not isinstance(did_bytes, bytes):
             raise TypeError('You must provide a 32 Byte value')
 
+        resolved = DIDResolved()
         result = None
         did_visited = {}
 
@@ -83,6 +176,7 @@ class DIDResolver():
                         result = data['value'].decode('utf8')
                     except:
                         raise TypeError('Invalid string (URL or DDO) data type for a DID value at {}'.format(Web3.toHex(did_bytes)))
+                resolved.add_data(data, result)
                 data = None
                 break
             elif data['value_type'] == VALUE_TYPE_DID:
@@ -91,6 +185,7 @@ class DIDResolver():
                     did_bytes = Web3.toBytes(hexstr=data['value'].decode('utf8'))
                 except:
                     raise TypeError('Invalid data type for a DID value at {}'.format(Web3.toHex(did_bytes)))
+                resolved.add_data(data, did_bytes)
                 result = did_bytes
             elif data['value_type'] == VALUE_TYPE_DID_REF:
                 # at the moment the same method as DID, get the hexstr and convert to bytes
@@ -99,6 +194,7 @@ class DIDResolver():
                     did_bytes = Web3.toBytes(hexstr=data['value'].decode('utf8'))
                 except:
                     raise TypeError('Invalid data type for a DID value at {}'.format(Web3.toHex(did_bytes)))
+                resolved.add_data(data, did_bytes)
                 result = did_bytes
             else:
                 raise OceanDIDUnknownValueType('Unknown value type {}'.format(data['value_type']))
@@ -112,7 +208,10 @@ class DIDResolver():
                 data = self.get_did(did_bytes)
 
             hop_count = hop_count + 1
-        return result
+            
+        if resolved.items:
+            return resolved
+        return None
 
 
 

--- a/squid_py/didresolver.py
+++ b/squid_py/didresolver.py
@@ -167,8 +167,7 @@ class DIDResolver():
 
         # resolve a DID to a URL or DDO
         data = self.get_did(did_bytes)
-        hop_count = 0
-        while data and (max_hop_count == 0 or hop_count < max_hop_count):
+        while data and (max_hop_count == 0 or resolved.hop_count < max_hop_count):
             if data['value_type'] == VALUE_TYPE_URL or data['value_type'] == VALUE_TYPE_DDO:
                 logger.info('found did {0} -> {1}'.format(Web3.toHex(did_bytes), data['value']))
                 if data['value']:
@@ -207,9 +206,8 @@ class DIDResolver():
                     raise OceanDIDCircularReference('circular reference found at did {}'.format(Web3.toHex(did_bytes)))
                 data = self.get_did(did_bytes)
 
-            hop_count = hop_count + 1
             
-        if resolved.items:
+        if resolved.hop_count > 0:
             return resolved
         return None
 

--- a/squid_py/didresolver.py
+++ b/squid_py/didresolver.py
@@ -137,6 +137,10 @@ class DIDResolver():
                 Web3.toBytes(hexstr=log_item['data']))
             result = {
                 'value_type': value_type,
-                'value': value
+                'value': value,
+                'block_number': block_number,
+                'did_bytes': log_item['topics'][1],
+                'owner': log_item['topics'][2],
+                'key': log_item['topics'][2],
             }
         return result

--- a/tests/test_didresolver.py
+++ b/tests/test_didresolver.py
@@ -146,6 +146,7 @@ def test_did_resolver_library():
     value_type = VALUE_TYPE_URL
     key_test = Web3.sha3(text='provider')
     value_test = 'http://localhost:5000'
+    key_zero = Web3.toBytes(hexstr='0x' + ('00' * 32))
 
     didresolver = DIDResolver(ocean._web3, ocean.keeper.didregistry)
 
@@ -158,7 +159,9 @@ def test_did_resolver_library():
     assert didresolved
     assert didresolved.is_url
     assert didresolved.url == value_test
-
+    assert didresolved.key == key_zero
+    assert didresolved.owner == register_account
+    
     with pytest.raises(ValueError):
         didresolver.resolve(did_id)
 
@@ -166,17 +169,27 @@ def test_did_resolver_library():
     assert didresolved
     assert didresolved.is_url
     assert didresolved.url == value_test
+    assert didresolved.key == key_zero
+    assert didresolved.owner == register_account
 
     # resolve URL from a hash of a DID string
     did_hash = Web3.sha3(text=did_test)
 
+    logger.info('register hash %s', Web3.toHex(did_hash))
     register_did = didregistry.register_attribute(did_hash, value_type, key_test, value_test, register_account)
     receipt = didregistry.get_tx_receipt(register_did)
+    print(receipt)
+    print('block number', didregistry.get_update_at(did_hash))
     gas_used_url = receipt['gasUsed']
     didresloved = didresolver.resolve(did_hash)
+    logger.info('register hash %s', Web3.toHex(did_hash))
+    print(didresolved.items)
     assert didresolved
     assert didresolved.is_url
     assert didresolved.url == value_test
+    assert didresolved.key == key_test
+    assert didresolved.value_type == value_type
+    assert didresolved.owner == register_account
 
     # test update of an already assigned DID
     value_test_new = 'http://aquarius:5000'

--- a/tests/test_didresolver.py
+++ b/tests/test_didresolver.py
@@ -161,7 +161,7 @@ def test_did_resolver_library():
     assert didresolved.url == value_test
     assert didresolved.key == key_zero
     assert didresolved.owner == register_account
-    
+
     with pytest.raises(ValueError):
         didresolver.resolve(did_id)
 
@@ -175,21 +175,17 @@ def test_did_resolver_library():
     # resolve URL from a hash of a DID string
     did_hash = Web3.sha3(text=did_test)
 
-    logger.info('register hash %s', Web3.toHex(did_hash))
     register_did = didregistry.register_attribute(did_hash, value_type, key_test, value_test, register_account)
     receipt = didregistry.get_tx_receipt(register_did)
-    print(receipt)
-    print('block number', didregistry.get_update_at(did_hash))
     gas_used_url = receipt['gasUsed']
-    didresloved = didresolver.resolve(did_hash)
-    logger.info('register hash %s', Web3.toHex(did_hash))
-    print(didresolved.items)
+    didresolved = didresolver.resolve(did_hash)
     assert didresolved
     assert didresolved.is_url
     assert didresolved.url == value_test
     assert didresolved.key == key_test
     assert didresolved.value_type == value_type
     assert didresolved.owner == register_account
+    assert didresolved.block_number == receipt['blockNumber']
 
     # test update of an already assigned DID
     value_test_new = 'http://aquarius:5000'
@@ -199,6 +195,10 @@ def test_did_resolver_library():
     assert didresolved
     assert didresolved.is_url
     assert didresolved.url == value_test_new
+    assert didresolved.key == key_test
+    assert didresolved.value_type == value_type
+    assert didresolved.owner == register_account
+    assert didresolved.block_number == receipt['blockNumber']
 
     # resolve DDO from a direct DID ID value
     ddo = DDO(did_test)
@@ -219,6 +219,10 @@ def test_did_resolver_library():
     assert didresolved
     assert didresolved.is_ddo
     assert ddo.calculate_hash() == resolved_ddo.calculate_hash()
+    assert didresolved.key == key_test
+    assert didresolved.value_type == value_type
+    assert didresolved.owner == register_account
+    assert didresolved.block_number == receipt['blockNumber']
 
     logger.info('gas used URL: %d, DDO: %d, DDO +%d extra', gas_used_url, gas_used_ddo, gas_used_ddo - gas_used_url)
 
@@ -246,6 +250,10 @@ def test_did_resolver_library():
     assert didresolved.is_url
     assert didresolved.url == value_test
     assert didresolved.hop_count == chain_length
+    assert didresolved.key == key_test
+    assert didresolved.value_type == value_type
+    assert didresolved.owner == register_account
+    assert didresolved.block_number == receipt['blockNumber']
 
 
     # test circular chain

--- a/tests/test_didresolver.py
+++ b/tests/test_didresolver.py
@@ -156,7 +156,7 @@ def test_did_resolver_library():
 
     didresolved = didresolver.resolve(did_test)
     assert didresolved
-    assert didresolved.is_url    
+    assert didresolved.is_url
     assert didresolved.url == value_test
 
     with pytest.raises(ValueError):
@@ -164,7 +164,7 @@ def test_did_resolver_library():
 
     didresolved = didresolver.resolve(did_id_bytes)
     assert didresolved
-    assert didresolved.is_url    
+    assert didresolved.is_url
     assert didresolved.url == value_test
 
     # resolve URL from a hash of a DID string
@@ -175,7 +175,7 @@ def test_did_resolver_library():
     gas_used_url = receipt['gasUsed']
     didresloved = didresolver.resolve(did_hash)
     assert didresolved
-    assert didresolved.is_url    
+    assert didresolved.is_url
     assert didresolved.url == value_test
 
     # test update of an already assigned DID
@@ -184,9 +184,9 @@ def test_did_resolver_library():
     receipt = didregistry.get_tx_receipt(register_did)
     didresolved = didresolver.resolve(did_hash)
     assert didresolved
-    assert didresolved.is_url    
+    assert didresolved.is_url
     assert didresolved.url == value_test_new
-    
+
     # resolve DDO from a direct DID ID value
     ddo = DDO(did_test)
     ddo.add_signature()
@@ -202,9 +202,9 @@ def test_did_resolver_library():
 
     didresolved = didresolver.resolve(did_id_bytes)
     resolved_ddo = DDO(json_text = didresolved.ddo)
-    
+
     assert didresolved
-    assert didresolved.is_ddo     
+    assert didresolved.is_ddo
     assert ddo.calculate_hash() == resolved_ddo.calculate_hash()
 
     logger.info('gas used URL: %d, DDO: %d, DDO +%d extra', gas_used_url, gas_used_ddo, gas_used_ddo - gas_used_url)
@@ -230,7 +230,7 @@ def test_did_resolver_library():
     did_id_bytes = Web3.toBytes(hexstr=ids[0])
     didresolved = didresolver.resolve(did_id_bytes)
     assert didresolved
-    assert didresolved.is_url    
+    assert didresolved.is_url
     assert didresolved.url == value_test
     assert didresolved.hop_count == chain_length
 


### PR DESCRIPTION
## Description

Add a ```DIDResolved``` object to be returned by the ```didresolver```. This provides all of the DIDRegistry event information of the final resolved DID.

## Is this PR related with an open issue?

Related to Issue #67 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()