### PR TITLE
Refactored how requirements are managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ contracts.folder =  # You can pass the directory of your contracts instead of us
     A bash script is available to copy these addresses into this file directly from a running docker image. This script needs to run in the root of the project. 
     
     ```
-    source ./script/deploy.sh
+    source ./scripts/deploy.sh
     ```
     
     Alternatively, you can manually enter the parameters in this file.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,65 +1,11 @@
-argh==0.26.2
-asn1crypto==0.24.0
-atomicwrites==1.1.5
-attrdict==2.0.0
-attrs==18.1.0
-bumpversion==0.5.3
-certifi==2018.8.13
-cffi==1.11.5
-chardet==3.0.4
-codacy-coverage==1.3.11
-coincurve==8.0.2
-coloredlogs==10.0
-coverage==4.5.1
-cryptography==2.3.1
-cytoolz==0.9.0.1
-eciespy==0.1.2
-docker==3.5.1
-eth-abi==1.2.0
-eth-account==0.3.0
-eth-hash==0.2.0
-eth-keyfile==0.5.1
-eth-keys==0.2.0b3
-eth-rlp==0.1.2
-eth-typing==1.1.0
-eth-utils==1.2.0
-flake8==3.5.0
-hexbytes==0.1.0
-humanfriendly==4.16.1
-idna==2.7
-keeper-contracts==0.3.12
-lru-dict==1.1.6
-mccabe==0.6.1
-more-itertools==4.3.0
-parsimonious==0.8.0
-pathtools==0.1.2
-pkginfo==1.4.2
-pluggy==0.7.1
-py==1.5.4
-py-solc==3.1.0
-pycodestyle==2.3.1
-pycparser==2.18
-pycryptodome==3.6.6
-pycryptodomex==3.6.6
-pyflakes==1.6.0
-PyJWT==1.6.4
-pyOpenSSL==18.0.0
-pysha3==1.0.2
-pytest==3.7.2
-pytest-runner==4.2
-PyYAML==3.13
-requests==2.19.1
-requests-toolbelt==0.8.0
-rlp==1.0.2
-semantic-version==2.6.0
-singletonify==0.1.2.0
-six==1.11.0
-toolz==0.9.0
-tox==3.2.1
-tqdm==4.25.0
-twine==1.11.0
-urllib3==1.23
-virtualenv==16.0.0
-watchdog==0.8.3
-web3==4.7.1
-websockets==6.0.0
+# pip install squid-py
+# is for end users. That will install the packages
+# listed in the install_requires list of setup.py.
+
+# pip install -r requirements_dev.txt
+# is for the developers of squid-py, so doing that should
+# install all the Python packages listed
+# in the install_requires list of setup.py
+# and also the 'dev' list in the extras_require dict
+
+-e .[dev]

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,45 @@ with open('README.md') as readme_file:
 with open('HISTORY.md') as history_file:
     history = history_file.read()
 
-requirements = ['keeper-contracts', 'web3==4.5.0', 'pyyaml', 'coloredlogs']
+# Installed by pip install squid-py
+# or pip install -e .
+install_requirements = [
+    'coloredlogs',
+    'eciespy',
+    'keeper-contracts',
+    'pyopenssl',
+    'PyJWT',  # not jwt
+    'PyYAML',
+    'web3==4.5.0',
+    # web3 requires eth-abi, requests, and more, so those will be installed too.
+    # See https://github.com/ethereum/web3.py/blob/master/setup.py
+]
 
+# Required to run setup.py:
 setup_requirements = ['pytest-runner', ]
 
-test_requirements = ['pytest', ]
+test_requirements = [
+    'codacy-coverage',
+    'coverage',
+    'docker',
+    'flake8',
+    'mccabe',
+    'pyflakes',
+    'pytest',
+    'tox',
+]
+
+# Possibly required by developers of squid-py:
+dev_requirements = [
+    'bumpversion',
+    'pkginfo',
+    'twine',
+    'watchdog',
+]
+
+docs_requirements = [
+    'Sphinx',
+]
 
 setup(
     author="leucothia",
@@ -28,7 +62,11 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     description="🐳 Ocean/Web3py wrapper.",
-    install_requires=requirements,
+    extras_require={
+        'test': test_requirements,
+        'dev': dev_requirements + test_requirements + docs_requirements,
+    },
+    install_requires=install_requirements,
     license="Apache Software License 2.0",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Moved the list of Python package requirements to the `setup.py` file, but kept the `requirements_dev.txt` file for folks who use it as part of their workflow (and for tox). It just uses the `setup.py` file now (implicitly).

Deleted many un-needed packages from the lists of requirements.

Some of the `dev_requirements` might not actually be required by any squid-py devs, but I kept them around just in case.

All the tests passed on my local machine.

Also fixed a small typo in `README.md`.

Resolves #65 

This PR should also resolve the security warning from GitHub about the `requests` package.