### PR TITLE
Remove all bumpversion settings from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.1.3
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:squid_py/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 
@@ -23,4 +10,3 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-


### PR DESCRIPTION
because a `.bumpversion.cfg` file exists and `bumpversion` looks there first, so the values in `setup.cfg` were being ignored anyway.

An alternative solution would be to delete the `.bumpversion.cfg` file and to update `current_version` to 0.2.4 in `setup.cfg` (because if a `.bumpversion.cfg` file doesn't exist, `bumpversion` will look in `setup.cfg` next).