### PR TITLE
Success:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,10 @@ install_requirements = [
     'PyJWT',  # not jwt
     'PyYAML',
     'web3==4.5.0',
-    'ocean-secret-store-client==0.0.1',
+    'ocean-secret-store-client==0.0.1'
     # web3 requires eth-abi, requests, and more,
     # so those will be installed too.
     # See https://github.com/ethereum/web3.py/blob/master/setup.py
-    'ocean-secret-store-client==0.0.1'
 ]
 
 # Required to run setup.py:

--- a/squid_py/ocean/ocean.py
+++ b/squid_py/ocean/ocean.py
@@ -282,11 +282,12 @@ class Ocean:
         prefixed_hash = prepare_prefixed_hash(agreement_hash)
         # :NOTE: An alternative to `web3.eth.account.recoverHash`, we can
         # use `eth_keys.KeyAPI.PublicKey.recover_from_msg_hash()` just like we do
-        # in `squid_py.utils.utilities.get_publickey_from_address`. When using that, make sure
-        # to use `split_signature` with `v01` set to True because KeyAPI only supports `v` values of 0 or 1
+        # in `squid_py.utils.utilities.get_public-key_from_address`. When using that, make sure
+        # to manipulate the `v` value because KeyAPI only supports `v` values of 0 or 1
         # but some eth clients can produce a `v` of 27 or 28. This is why we have to use
         # the `recover_from_msg_hash` method with the `vrs` argument instead of `signature` unless we
-        # reassemble the signature from the split `(v,r,s)` tuple.
+        # reassemble the signature from the split `(v,r,s)` tuple. Also must use the prefixed hash
+        # message to get an accurate recovery of public-key and address.
         recovered_address = self._web3.eth.account.recoverHash(prefixed_hash, signature=signature)
         return recovered_address == consumer_address
 

--- a/squid_py/service_agreement/utils.py
+++ b/squid_py/service_agreement/utils.py
@@ -93,7 +93,7 @@ def register_service_agreement_template(service_agreement_contract, contract_pat
 
 def make_public_key_and_authentication(did, publisher_address, web3):
     # set public key
-    public_key_value = get_publickey_from_address(web3, publisher_address)
+    public_key_value = get_publickey_from_address(web3, publisher_address).to_hex()
     pub_key = PublicKeyBase('keys-1', **{'value': public_key_value, 'owner': publisher_address,
                                          'type': PUBLIC_KEY_STORE_TYPE_HEX})
     pub_key.assign_did(did)

--- a/tests/test_ddo.py
+++ b/tests/test_ddo.py
@@ -246,7 +246,7 @@ def test_creating_did_using_ddo():
 def test_load_ddo_json():
     # TODO: Fix
     SAMPLE_DDO_PATH = pathlib.Path.cwd() / 'tests' / 'resources' / 'ddo' / 'ddo_sample1.json'
-    assert SAMPLE_DDO_PATH.exists(), "{} does not exist!".format(SAMPLE_METADATA_PATH)
+    assert SAMPLE_DDO_PATH.exists(), "{} does not exist!".format(SAMPLE_DDO_PATH)
     with open(SAMPLE_DDO_PATH) as f:
         SAMPLE_DDO_JSON_DICT = json.load(f)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from web3 import Web3
+import pytest
 
 from squid_py.utils import utilities
 
@@ -9,6 +10,18 @@ def test_split_signature():
     assert split_signature.v == 28
     assert split_signature.r == b'\x19\x15!\xecwnX1o/\xdeho\x9a9\xdd9^\xbb\x8c2z\x88!\x95\xdc=\xe6\xafc\x0f\xe9'
     assert split_signature.s == b'\x14\x12\xc6\xde\x0b\n\xa6\x11\xc0\x1cvv\x9f\x99O8\x15\xf6f\xe7\xab\xea\x982Ds\x0bX\xd9\x94\xa42'
+
+
+def test_get_publickey_from_address(ocean_instance):
+    from eth_keys.exceptions import BadSignature
+    for account in ocean_instance.accounts:
+        try:
+            pub_key = utilities.get_publickey_from_address(ocean_instance._web3, account)
+            assert pub_key.to_checksum_address() == account, 'recovered public key address does not match original address.'
+        except BadSignature:
+            pytest.fail("BadSignature")
+        except ValueError:
+            pass
 
 
 def test_convert():


### PR DESCRIPTION
* Verifying consumer signature of service agreement hash
* Recover public key from ethereum address by using a dummy signed message
  * This required a work around to handle the 0/1 of the `v` portion of a signature in addition to the typical 27/28 values.

## Description

Fix bugs related to recovering public key from ethereum signature.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()