### PR TITLE
Feature/handle timeout refund consume

### DIFF
--- a/squid_py/keeper/conditions/access_conditions.py
+++ b/squid_py/keeper/conditions/access_conditions.py
@@ -5,3 +5,6 @@ class AccessConditions(ContractBase):
 
     def __init__(self, web3, contract_path):
         super().__init__(web3, contract_path, 'AccessConditions')
+
+    def check_permissions(self, address, asset_id, sender_address):
+        self.contract_concise.checkPermissions(address, asset_id, call={'from': sender_address})

--- a/squid_py/keeper/contract_base.py
+++ b/squid_py/keeper/contract_base.py
@@ -68,7 +68,7 @@ class ContractBase(object):
         """Return the event signature from a named event. """
         signature = None
         for item in self.contract.abi:
-            if 'name' in item and item['name'] == name and item['type'] == 'event':
+            if item.get('type') == 'event' and item.get('name') == name:
                 signature = item['signature']
                 break
 

--- a/squid_py/keeper/utils.py
+++ b/squid_py/keeper/utils.py
@@ -41,6 +41,14 @@ def get_contract_instance(web3, contract_path, contract_name, network_name=None)
     return web3.eth.contract(address=address, abi=abi)
 
 
+def get_event_def_from_abi(abi, event_name):
+    for item in abi:
+        if 'type' in item and item['type'] == 'event' and item['name'] == event_name:
+            return item
+
+    raise ValueError('event {} not found in the given ABI'.format(event_name))
+
+
 def get_fingerprint_by_name(abi, name):
     for item in abi:
         if 'name' in item and item['name'] == name:

--- a/squid_py/keeper/utils.py
+++ b/squid_py/keeper/utils.py
@@ -43,7 +43,7 @@ def get_contract_instance(web3, contract_path, contract_name, network_name=None)
 
 def get_event_def_from_abi(abi, event_name):
     for item in abi:
-        if 'type' in item and item['type'] == 'event' and item['name'] == event_name:
+        if item.get('type') == 'event' and item.get('name') == event_name:
             return item
 
     raise ValueError('event {} not found in the given ABI'.format(event_name))
@@ -51,7 +51,7 @@ def get_event_def_from_abi(abi, event_name):
 
 def get_fingerprint_by_name(abi, name):
     for item in abi:
-        if 'name' in item and item['name'] == name:
+        if item.get('name') == name:
             return item['signature']
 
     raise ValueError('{} not found in the given ABI'.format(name))

--- a/squid_py/modules/v0_1/accessControl.py
+++ b/squid_py/modules/v0_1/accessControl.py
@@ -3,6 +3,7 @@ from squid_py.modules.v0_1.utils import (
     get_condition_contract_data,
     is_condition_fulfilled,
 )
+from squid_py.service_agreement.service_agreement import ServiceAgreement
 
 
 def grantAccess(web3, contract_path, account, service_agreement_id, service_definition,
@@ -16,7 +17,6 @@ def grantAccess(web3, contract_path, account, service_agreement_id, service_defi
         service_definition,
         'grantAccess',
     )
-
     contract_name = service_definition['serviceAgreementContract']['contractName']
     service_agreement_address = get_contract_abi_and_address(web3, contract_path, contract_name)[1]
     if is_condition_fulfilled(web3, contract_path, service_definition['templateId'],
@@ -28,7 +28,18 @@ def grantAccess(web3, contract_path, account, service_agreement_id, service_defi
     name_to_parameter = {param['name']: param for param in parameters}
     access_conditions.grantAccess(
         service_agreement_id,
-        name_to_parameter['did']['value'],
-        name_to_parameter['did']['value'],
+        name_to_parameter['assetId']['value'],
+        name_to_parameter['assetId']['value'],
         transact={'from': account},
     )
+
+
+def consumeAsset(web3, contract_path, account, service_agreement_id, service_definition,
+                 consume_callback, *args, **kwargs):
+
+    if consume_callback:
+        consume_callback(
+            service_agreement_id, service_definition['id'],
+            service_definition[ServiceAgreement.SERVICE_DEFINITION_ID_KEY], account
+        )
+        return

--- a/squid_py/modules/v0_1/payment.py
+++ b/squid_py/modules/v0_1/payment.py
@@ -63,3 +63,33 @@ def releasePayment(web3, contract_path, account, service_agreement_id, service_d
         name_to_parameter['price']['value'],
         transact={'from': account},
     )
+
+
+def refundPayment(web3, contract_path, account, service_agreement_id, service_definition,
+                   *args, **kwargs):
+    """ Checks if the refundPayment condition has been fulfilled and if not calls
+        PaymentConditions.refundPayment smart contract function.
+    """
+    function_name = 'refundPayment'
+    payment_conditions, abi, payment_condition_definition = get_condition_contract_data(
+        web3,
+        contract_path,
+        service_definition,
+        function_name,
+    )
+
+    contract_name = service_definition['serviceAgreementContract']['contractName']
+    service_agreement_address = get_contract_abi_and_address(web3, contract_path, contract_name)[1]
+    if is_condition_fulfilled(web3, contract_path, service_definition['templateId'],
+                              service_agreement_id, service_agreement_address,
+                              payment_conditions.address, abi, function_name):
+        return
+
+    parameters = payment_condition_definition['parameters']
+    name_to_parameter = {param['name']: param for param in parameters}
+    payment_conditions.refundPayment(
+        service_agreement_id,
+        name_to_parameter['did']['value'],
+        name_to_parameter['price']['value'],
+        transact={'from': account},
+    )

--- a/squid_py/modules/v0_1/payment.py
+++ b/squid_py/modules/v0_1/payment.py
@@ -5,8 +5,8 @@ from squid_py.modules.v0_1.utils import (
 )
 
 
-def lockPayment(web3, contract_path, account, service_agreement_id, service_definition,
-                *args, **kwargs):
+def lockPayment(web3, contract_path, account, service_agreement_id,
+                service_definition, *args, **kwargs):
     """ Checks if the lockPayment condition has been fulfilled and if not calls
         PaymentConditions.lockPayment smart contract function.
 
@@ -30,14 +30,14 @@ def lockPayment(web3, contract_path, account, service_agreement_id, service_defi
     name_to_parameter = {param['name']: param for param in parameters}
     payment_conditions.lockPayment(
         service_agreement_id,
-        name_to_parameter['did']['value'],
+        name_to_parameter['assetId']['value'],
         name_to_parameter['price']['value'],
         transact={'from': account},
     )
 
 
-def releasePayment(web3, contract_path, account, service_agreement_id, service_definition,
-                   *args, **kwargs):
+def releasePayment(web3, contract_path, account, service_agreement_id,
+                   service_definition, *args, **kwargs):
     """ Checks if the releasePayment condition has been fulfilled and if not calls
         PaymentConditions.releasePayment smart contract function.
     """
@@ -59,14 +59,14 @@ def releasePayment(web3, contract_path, account, service_agreement_id, service_d
     name_to_parameter = {param['name']: param for param in parameters}
     payment_conditions.releasePayment(
         service_agreement_id,
-        name_to_parameter['did']['value'],
+        name_to_parameter['assetId']['value'],
         name_to_parameter['price']['value'],
         transact={'from': account},
     )
 
 
-def refundPayment(web3, contract_path, account, service_agreement_id, service_definition,
-                   *args, **kwargs):
+def refundPayment(web3, contract_path, account, service_agreement_id,
+                  service_definition, *args, **kwargs):
     """ Checks if the refundPayment condition has been fulfilled and if not calls
         PaymentConditions.refundPayment smart contract function.
     """
@@ -89,7 +89,7 @@ def refundPayment(web3, contract_path, account, service_agreement_id, service_de
     name_to_parameter = {param['name']: param for param in parameters}
     payment_conditions.refundPayment(
         service_agreement_id,
-        name_to_parameter['did']['value'],
+        name_to_parameter['assetId']['value'],
         name_to_parameter['price']['value'],
         transact={'from': account},
     )

--- a/squid_py/modules/v0_1/serviceAgreement.py
+++ b/squid_py/modules/v0_1/serviceAgreement.py
@@ -1,0 +1,21 @@
+from web3.contract import ConciseContract
+
+from squid_py.keeper.utils import get_contract_abi_and_address
+
+
+def fulfillAgreement(web3, contract_path, account, service_agreement_id, service_definition,
+                *args, **kwargs):
+    """ Checks if serviceAgreement has been fulfilled and if not calls
+        ServiceAgreement.fulfillAgreement smart contract function.
+    """
+    contract_name = service_definition['serviceAgreementContract']['contractName']
+    abi, service_agreement_address = get_contract_abi_and_address(web3, contract_path, contract_name)
+    service_agreement = web3.eth.contract(address=service_agreement_address, abi=abi, ContractFactoryClass=ConciseContract)
+    service_agreement.fulfillAgreement(
+        service_agreement_id,
+        transact={'from': account},
+    )
+
+
+def terminateAgreement(web3, contract_path, account, service_agreement_id, service_definition, *args, **kwargs):
+    fulfillAgreement(web3, contract_path, account, service_agreement_id, service_definition, *args, **kwargs)

--- a/squid_py/modules/v0_1/serviceAgreement.py
+++ b/squid_py/modules/v0_1/serviceAgreement.py
@@ -3,8 +3,8 @@ from web3.contract import ConciseContract
 from squid_py.keeper.utils import get_contract_abi_and_address
 
 
-def fulfillAgreement(web3, contract_path, account, service_agreement_id, service_definition,
-                *args, **kwargs):
+def fulfillAgreement(web3, contract_path, account, service_agreement_id,
+                     service_definition, *args, **kwargs):
     """ Checks if serviceAgreement has been fulfilled and if not calls
         ServiceAgreement.fulfillAgreement smart contract function.
     """
@@ -17,5 +17,6 @@ def fulfillAgreement(web3, contract_path, account, service_agreement_id, service
     )
 
 
-def terminateAgreement(web3, contract_path, account, service_agreement_id, service_definition, *args, **kwargs):
+def terminateAgreement(web3, contract_path, account, service_agreement_id,
+                       service_definition, *args, **kwargs):
     fulfillAgreement(web3, contract_path, account, service_agreement_id, service_definition, *args, **kwargs)

--- a/squid_py/ocean/account.py
+++ b/squid_py/ocean/account.py
@@ -2,7 +2,7 @@ from squid_py.models.balance import Balance
 
 
 class Account:
-    def __init__(self, keeper, address):
+    def __init__(self, keeper, address, password=None):
         """
         Hold account address, and update balances of Ether and Ocean token
 
@@ -11,6 +11,7 @@ class Account:
         """
         self.keeper = keeper
         self.address = address
+        self.password = password
         self.balance = self.get_balance()
 
     def request_tokens(self, amount):

--- a/squid_py/ocean/ocean.py
+++ b/squid_py/ocean/ocean.py
@@ -61,8 +61,14 @@ class Ocean:
 
         # Collect the accounts
         self.accounts = self.get_accounts()
-
         assert self.accounts
+
+        if self.config.parity_address and self.config.parity_address in self.accounts:
+            self.main_account = self.accounts.get(self.config.parity_address,
+                                                  Account(self.keeper, self.config.parity_address, self.config.parity_password))
+            self.main_account.address = self.config.parity_password
+        else:
+            self.main_account = self.accounts[self._web3.eth.accounts[0]]
 
         self.did_resolver = DIDResolver(self._web3, self.keeper.didregistry)
 
@@ -179,7 +185,8 @@ class Ocean:
 
         return ddo
 
-    def sign_service_agreement(self, did, service_definition_id, consumer):
+    def sign_service_agreement(self, did, service_definition_id, consumer_address):
+        assert consumer_address in self.accounts, 'Unrecognized consumer address %s' % consumer_address
         service_agreement_id = '0x%s' % generate_new_id()
         # Extract all of the params necessary for execute agreement from the ddo
         ddo = DDO(json_text=json.dumps(self.metadata_store.get_asset_metadata(did)))
@@ -193,21 +200,21 @@ class Ocean:
         sa = ServiceAgreement.from_service_dict(service)
         purchase_endpoint = sa.purchase_endpoint
 
-        signature, sa_hash = sa.get_signed_agreement_hash(self._web3, did_to_id(did), service_agreement_id, consumer)
+        signature, sa_hash = sa.get_signed_agreement_hash(self._web3, did_to_id(did), service_agreement_id, consumer_address)
         # Prepare a payload to send to `Brizo`
         payload = json.dumps({
             'did': did,
             'serviceAgreementId': service_agreement_id,
             'serviceDefinitionId': service_definition_id,
             'signature': signature,
-            'consumerPublicKey': consumer
+            'consumerPublicKey': consumer_address
         })
         requests.post(purchase_endpoint, data=payload, headers={'content-type': 'application/json'})
 
         # subscribe to events related to this service_agreement_id
-        register_service_agreement(self._web3, self.keeper.contract_path, self.config.storage_path, consumer,
+        register_service_agreement(self._web3, self.keeper.contract_path, self.config.storage_path, consumer_address,
                                    service_agreement_id, did, service, 'consumer', service_definition_id,
-                                   sa.get_price(), content_urls, 3)
+                                   sa.get_price(), content_urls, self.consume_service, 3)
 
         return service_agreement_id
 
@@ -233,6 +240,8 @@ class Ocean:
         """
         assert consumer_address and self._web3.isChecksumAddress(consumer_address), 'Invalid consumer address "%s"' % consumer_address
         assert publisher_address and self._web3.isChecksumAddress(publisher_address), 'Invalid publisher address "%s"' % publisher_address
+        assert publisher_address in self.accounts, 'Unrecognized publisher address %s' % publisher_address
+
         # Extract all of the params necessary for execute agreement from the ddo
         ddo = DDO(json_text=json.dumps(self.metadata_store.get_asset_metadata(did)))
         service = ddo.find_service_by_key_value(ServiceAgreement.SERVICE_DEFINITION_ID_KEY, service_definition_id)
@@ -261,7 +270,7 @@ class Ocean:
         # subscribe to events related to this service_agreement_id
         register_service_agreement(self._web3, self.keeper.contract_path, self.config.storage_path, publisher_address,
                                    service_agreement_id, did, service, 'publisher', service_definition_id,
-                                   sa.get_price(), content_urls, 3)
+                                   sa.get_price(), content_urls, None, 3)
 
         return receipt
 
@@ -270,14 +279,17 @@ class Ocean:
         Verify on-chain that the `consumer_address` has permission to access the given `asset_did` according to the `service_agreement_id`.
 
         :param service_agreement_id:
-        :param asset_did:
+        :param did:
         :param consumer_address:
         :return: bool True if user has permission
         """
-        # :TODO:
-        #   1. ensure service_agreement_id is actually executed on-chain and is associated to both asset_id and consumer_address
+        agreement_consumer = self.keeper.service_agreement.get_service_agreement_consumer(service_agreement_id)
+        if agreement_consumer != consumer_address:
+            print('Invalid consumer address and/or service agreement id.')
+            return False
 
-        return True
+        document_id = did_to_id(did)
+        return self.keeper.access_conditions.check_permissions(consumer_address, document_id, self.main_account.address)
 
     def verify_service_agreement_signature(self, did, service_agreement_id, service_definition_id, consumer_address, signature, ddo=None):
         if not ddo:
@@ -346,12 +358,43 @@ class Ocean:
         return None for no encryption performed
         """
         result = None
-        if self.config.secret_store_url and self.config.parity_url and self.config.parity_address:
+        if self.config.secret_store_url and self.config.parity_url and self.main_account:
             publisher = Client(self.config.secret_store_url, self.config.parity_url,
-                               self.config.parity_address, self.config.parity_password)
+                               self.main_account.address, self.main_account.password)
 
             document_id = did_to_id(did)
-            # TODO: need to remove below to stop multiple session testing so that we can encrypt using the id from the DID.
-            # document_id = secrets.token_hex(32)
             result = publisher.publish_document(document_id, data)
         return result
+
+    def _decrypt_content_urls(self, did, encrypted_data):
+        result = None
+        if self.config.secret_store_url and self.config.parity_url and self.main_account:
+            consumer = Client(self.config.secret_store_url, self.config.parity_url,
+                              self.main_account.address, self.main_account.password)
+
+            document_id = did_to_id(did)
+            result = consumer.decrypt_document(document_id, encrypted_data)
+
+        return result
+
+    def consume_service(self, service_agreement_id, did, service_definition_id, consumer_address):
+        ddo = self.resolve_did(did)
+
+        metadata_service = ddo.get_service(service_type=ServiceTypes.METADATA)
+        content_urls = metadata_service.get_values()['metadata']['base']['contentUrls']
+        service = ddo.find_service_by_key_value(ServiceAgreement.SERVICE_DEFINITION_ID_KEY, service_definition_id)
+        sa = ServiceAgreement.from_service_dict(service)
+        service_url = sa.service_endpoint
+        if not service_url:
+            print('Consume asset failed, service definition is missing the "serviceEndpoint".')
+            raise AssertionError('Consume asset failed, service definition is missing the "serviceEndpoint".')
+
+        # decrypt the contentUrls
+        decrypted_content_urls = self._decrypt_content_urls(did, content_urls)
+        print('got decrypted contentUrls: ', decrypted_content_urls)
+        consume_url = (
+            '%s?url=%s&serviceAgreementId=%s&consumerAddress=%s'
+            % (service_url, decrypted_content_urls, service_agreement_id, consumer_address)
+        )
+        response = requests.get(consume_url)
+        print('got consume response: ', response)

--- a/squid_py/service_agreement/access_sla_template.json
+++ b/squid_py/service_agreement/access_sla_template.json
@@ -154,7 +154,7 @@
             "functionName": "terminateAgreement",
             "version": "0.1"
           }
-        },
+        }
       ],
       "dependencies": ["lockPayment", "grantAccess"],
       "dependencyTimeoutFlags": [0, 1],

--- a/squid_py/service_agreement/access_sla_template.json
+++ b/squid_py/service_agreement/access_sla_template.json
@@ -41,9 +41,7 @@
       "events": [
         {
           "name": "PaymentLocked",
-          "actorType": [
-            "publisher"
-          ],
+          "actorType": "publisher",
           "handler": {
             "moduleName": "accessControl",
             "functionName": "grantAccess",
@@ -114,9 +112,7 @@
       "events": [
         {
           "name": "PaymentReleased",
-          "actorType": [
-            "consumer"
-          ],
+          "actorType": "consumer",
           "handler": {
             "moduleName": "serviceAgreement",
             "functionName": "fulfillAgreement",

--- a/squid_py/service_agreement/access_sla_template.json
+++ b/squid_py/service_agreement/access_sla_template.json
@@ -44,7 +44,7 @@
           "actorType": [
             "publisher"
           ],
-          "handlers": {
+          "handler": {
             "moduleName": "accessControl",
             "functionName": "grantAccess",
             "version": "0.1"
@@ -74,9 +74,18 @@
           "actorType": [
             "consumer"
           ],
-          "handlers": {
+          "handler": {
             "moduleName": "paymentProcessing",
             "functionName": "releasePayment",
+            "version": "0.1"
+          }
+        },
+        {
+          "name": "AccessTimeout",
+          "actorType": "consumer",
+          "handler": {
+            "moduleName": "paymentProcessing",
+            "functionName": "refundPayment",
             "version": "0.1"
           }
         }
@@ -108,7 +117,7 @@
           "actorType": [
             "consumer"
           ],
-          "handlers": {
+          "handler": {
             "moduleName": "serviceAgreement",
             "functionName": "fulfillAgreement",
             "version": "0.1"
@@ -139,15 +148,13 @@
       "events": [
         {
           "name": "PaymentRefund",
-          "actorType": [
-            "consumer", "publisher"
-          ],
-          "handlers": {
+          "actorType": "publisher",
+          "handler": {
             "moduleName": "serviceAgreement",
             "functionName": "terminateAgreement",
             "version": "0.1"
           }
-        }
+        },
       ],
       "dependencies": ["lockPayment", "grantAccess"],
       "dependencyTimeoutFlags": [0, 1],

--- a/squid_py/service_agreement/event_listener.py
+++ b/squid_py/service_agreement/event_listener.py
@@ -2,77 +2,128 @@ import importlib
 
 from squid_py.keeper.service_agreement import ServiceAgreement
 from squid_py.keeper.utils import get_contract_instance
+from squid_py.service_agreement.service_agreement_condition import ServiceAgreementCondition, Event
+from squid_py.service_agreement.storage import update_service_agreement_status
 from squid_py.utils import watch_event
 
-from .storage import record_service_agreement
+MIN_TIMEOUT = 3  # seconds
+MAX_TIMEOUT = 60 * 60 * 24 * 7  # 7 days expressed in seconds
+
+
+def get_event_handler_function(event):
+    fn_name = event.handler_function_name
+    version = event.handler_version.replace('.', '_')
+    import_path = 'squid_py.modules.v{}.{}'.format(version, event.handler_module_name)
+    module = importlib.import_module(import_path, 'squid_py')
+    return getattr(module, fn_name)
 
 
 def watch_service_agreement_events(web3, contract_path, storage_path, account, did,
                                    service_agreement_id, service_definition, actor_type,
-                                   num_confirmations=12):
+                                   start_time, num_confirmations=12):
     """ Subscribes to the events defined in the given service definition, targeted
         for the given actor type. Filters events by the given service agreement ID.
 
         The service definition format is described in OEP-11.
     """
 
-    filters = {ServiceAgreement.SERVICE_AGREEMENT_ID: web3.toBytes(hexstr=service_agreement_id)}
+    # filters = {ServiceAgreement.SERVICE_AGREEMENT_ID: web3.toBytes(hexstr=service_agreement_id)}
 
     # subscribe cleanup
     def _cleanup(event):
-        record_service_agreement(storage_path, service_agreement_id, did, 'fulfilled')
+        update_service_agreement_status(storage_path, service_agreement_id, 'fulfilled')
 
     watch_service_agreement_fulfilled(web3, contract_path, service_agreement_id, service_definition,
-                                      _cleanup, num_confirmations=num_confirmations)
+                                      _cleanup, start_time, num_confirmations=num_confirmations)
 
     # collect service agreement and condition events
     events = []
 
+    # Events from agreement contract `serviceAgreementContract` section. These are the initial
+    # events from executing the service agreement.
     for event in service_definition['serviceAgreementContract']['events']:
         if event['actorType'] != actor_type:
                 continue
 
-        events.append((service_definition['serviceAgreementContract']['contractName'], event))
+        events.append((service_definition['serviceAgreementContract']['contractName'], Event(event)))
 
-    for condition in service_definition['conditions']:
-        for event in condition['events']:
-            if event['actorType'] != actor_type:
+    conditions = [ServiceAgreementCondition(condition_json=condition_dict)
+                  for condition_dict in service_definition['conditions']]
+    name_to_cond = {cond.name: cond for cond in conditions}
+    # Events from conditions
+    cond_to_dependants_timeouts = {}
+    for cond_instance in conditions:
+        if cond_instance.dependencies and cond_instance.timeout > 0:
+            for i, cond_dep_name in enumerate(cond_instance.dependencies):
+                if cond_instance.timeout_flags[i] == 1:
+                    # dependency has a timeout
+                    assert cond_dep_name in name_to_cond, 'dependency name "%s" not found in conditions' % cond_dep_name
+                    cond_to_dependants_timeouts[cond_dep_name] = [(cond_instance.name, cond_instance.timeout)]
+
+    for cond_instance in conditions:
+        _dependent_cond_timeout = None
+        timeout_event = None
+        if cond_to_dependants_timeouts.get(cond_instance.name):
+            _dependent_cond_timeout = cond_to_dependants_timeouts.get(cond_instance.name)[0]
+            timeout_events = [event for event in cond_instance.events if event.name.endswith('Timeout')]
+            timeout_event = timeout_events[0] if timeout_events else None
+            if not timeout_event:
+                raise AssertionError('Expected a timeout event in this condition "%s" because another '
+                                     'condition "%s" depends on this condition timing out.' % (cond_instance.name, _dependent_cond_timeout[0], ))
+
+        for event in cond_instance.events:
+            if event.actor_type != actor_type or event.name.endswith('Timeout'):
                 continue
-            events.append((condition['contractName'], event))
+            events.append((cond_instance.contract_name, event, _dependent_cond_timeout, timeout_event))
 
     # subscribe to the events
-    for contract_name, event in events:
-        event_handler = event['handler']
-        version = event_handler['version'].replace('.', '_')
-        import_path = 'squid_py.modules.v{}.{}'.format(version, event_handler['moduleName'])
-        module = importlib.import_module(import_path, 'squid_py')
-        fn = getattr(module, event_handler['functionName'])
+    for contract_name, event, dependent_cond_timeout, timeout_event in events:
+        dependent_cond, timeout = None, None
+        if dependent_cond_timeout and timeout_event:
+            dependent_cond_name, timeout = dependent_cond_timeout
+            # dependent_cond = name_to_cond[dependent_cond_name]
 
-        def _get_callback(fn):
+        # event of type service_agreement_condition.Event
+        fn = get_event_handler_function(event)
+        if timeout_event and timeout:
+            assert MIN_TIMEOUT < timeout < MAX_TIMEOUT, 'TIMEOUT value not within allowed range %s.' % (MIN_TIMEOUT, MAX_TIMEOUT)
+            timeout_fn = get_event_handler_function(timeout_event)
+
+        def _get_callback(func_to_call):
             def _callback(payload):
-                fn(web3, contract_path, account, service_agreement_id, service_definition, payload)
+                func_to_call(web3, contract_path, account, service_agreement_id, service_definition, payload)
 
             return _callback
 
         contract = get_contract_instance(web3, contract_path, contract_name)
+        service_id_arg_name = contract.events[event.name].argument_names[0]
+        assert service_id_arg_name in ('serviceId', ServiceAgreement.SERVICE_AGREEMENT_ID), \
+            'unknown event first arg, expected serviceAgreementId, got "%s"' % service_id_arg_name
 
         # FIXME change this after AccessConditions contract is fixed
-        _filters = filters \
-                   if event_handler['functionName'] == 'lockPayment' \
-                   else {'serviceId': web3.toBytes(hexstr=service_agreement_id)}
+        _filters = {service_id_arg_name: web3.toBytes(hexstr=service_agreement_id)}\
+        #         (
+        #     filters
+        #     if event_name == 'ExecuteAgreement'
+        #     else {'serviceId': web3.toBytes(hexstr=service_agreement_id)}
+        # )
+
         watch_event(
             contract,
-            event['name'],
+            event.name,
             _get_callback(fn),
-            fromBlock='latest',
             interval=0.5,
+            start_time=start_time,
+            timeout=timeout,
+            timeout_callback=_get_callback(timeout_fn),
+            fromBlock='latest',
             filters=_filters,
             num_confirmations=num_confirmations,
         )
 
 
 def watch_service_agreement_fulfilled(web3, contract_path, service_agreement_id, service_definition,
-                                      callback, num_confirmations=12):
+                                      callback, start_time, num_confirmations=12):
     """ Subscribes to the service agreement fulfilled event, filtering by the given
         service agreement ID.
     """
@@ -84,8 +135,9 @@ def watch_service_agreement_fulfilled(web3, contract_path, service_agreement_id,
         contract,
         'AgreementFulfilled',
         callback,
-        fromBlock='latest',
         interval=0.5,
+        start_time=start_time,
+        fromBlock='latest',
         filters=filters,
         num_confirmations=num_confirmations,
     )

--- a/squid_py/service_agreement/register_service_agreement.py
+++ b/squid_py/service_agreement/register_service_agreement.py
@@ -6,11 +6,13 @@ from .storage import get_service_agreements, record_service_agreement
 
 def register_service_agreement(web3, contract_path, storage_path, account, service_agreement_id,
                                did, service_definition, actor_type, service_index, price,
-                               content_urls, num_confirmations=12):
+                               content_urls, num_confirmations=12, start_time=None):
     """ Registers the given service agreement in the local storage.
         Subscribes to the service agreement events.
     """
-    start_time = datetime.now()
+    if start_time is None:
+        start_time = int(datetime.now().timestamp())
+
     record_service_agreement(storage_path, service_agreement_id, service_index, price, content_urls, start_time, did)
     watch_service_agreement_events(
         web3, contract_path, storage_path, account, did,

--- a/squid_py/service_agreement/register_service_agreement.py
+++ b/squid_py/service_agreement/register_service_agreement.py
@@ -6,7 +6,7 @@ from .storage import get_service_agreements, record_service_agreement
 
 def register_service_agreement(web3, contract_path, storage_path, account, service_agreement_id,
                                did, service_definition, actor_type, service_index, price,
-                               content_urls, num_confirmations=12, start_time=None):
+                               content_urls, consume_callback=None, num_confirmations=12, start_time=None):
     """ Registers the given service agreement in the local storage.
         Subscribes to the service agreement events.
     """
@@ -17,7 +17,7 @@ def register_service_agreement(web3, contract_path, storage_path, account, servi
     watch_service_agreement_events(
         web3, contract_path, storage_path, account, did,
         service_agreement_id, service_definition, actor_type,
-        start_time,
+        start_time, consume_callback,
         num_confirmations
     )
 

--- a/squid_py/service_agreement/register_service_agreement.py
+++ b/squid_py/service_agreement/register_service_agreement.py
@@ -1,17 +1,23 @@
+from datetime import datetime
+
 from .event_listener import watch_service_agreement_events
 from .storage import get_service_agreements, record_service_agreement
 
 
 def register_service_agreement(web3, contract_path, storage_path, account, service_agreement_id,
-                               did, service_definition, actor_type, num_confirmations=12):
+                               did, service_definition, actor_type, service_index, price,
+                               content_urls, num_confirmations=12):
     """ Registers the given service agreement in the local storage.
         Subscribes to the service agreement events.
     """
-
-    record_service_agreement(storage_path, service_agreement_id, did)
-    watch_service_agreement_events(web3, contract_path, storage_path, account, did,
-                                   service_agreement_id, service_definition, actor_type,
-                                   num_confirmations)
+    start_time = datetime.now()
+    record_service_agreement(storage_path, service_agreement_id, service_index, price, content_urls, start_time, did)
+    watch_service_agreement_events(
+        web3, contract_path, storage_path, account, did,
+        service_agreement_id, service_definition, actor_type,
+        start_time,
+        num_confirmations
+    )
 
 
 def execute_pending_service_agreements(web3, contract_path, storage_path, account, actor_type,
@@ -19,12 +25,13 @@ def execute_pending_service_agreements(web3, contract_path, storage_path, accoun
     """ Iterates over pending service agreements recorded in the local storage,
         fetches their service definitions, and subscribes to service agreement events.
     """
-    for service_agreement_id, did, _ in get_service_agreements(storage_path):
+    # service_agreement_id, did, service_index, price, content_urls, start_time, status
+    for service_agreement_id, did, service_index, price, content_urls, start_time, _ in get_service_agreements(storage_path):
         ddo = did_resolver_fn(did)
         for service_definition in ddo['service']:
             if service_definition['type'] != 'Access':
                 continue
 
-            watch_service_agreement_events(web3, contract_path, storage_path, account,
-                                           did, service_agreement_id, service_definition, actor_type,
-                                           num_confirmations=num_confirmations)
+            watch_service_agreement_events(web3, contract_path, storage_path, account, did,
+                                           service_agreement_id, service_definition, actor_type,
+                                           start_time, num_confirmations=num_confirmations)

--- a/squid_py/service_agreement/register_service_agreement.py
+++ b/squid_py/service_agreement/register_service_agreement.py
@@ -13,7 +13,7 @@ def register_service_agreement(web3, contract_path, storage_path, account, servi
     if start_time is None:
         start_time = int(datetime.now().timestamp())
 
-    record_service_agreement(storage_path, service_agreement_id, service_index, price, content_urls, start_time, did)
+    record_service_agreement(storage_path, service_agreement_id, did, service_index, price, content_urls, start_time)
     watch_service_agreement_events(
         web3, contract_path, storage_path, account, did,
         service_agreement_id, service_definition, actor_type,

--- a/squid_py/service_agreement/service_agreement.py
+++ b/squid_py/service_agreement/service_agreement.py
@@ -20,6 +20,11 @@ class ServiceAgreement(object):
         self.purchase_endpoint = purchase_endpoint
         self.service_endpoint = service_endpoint
 
+    def get_price(self):
+        for cond in self.conditions:
+            for p in cond.parameters:
+                if p.name == 'price':
+                    return p.value
 
     @property
     def conditions_params_value_hashes(self):

--- a/squid_py/service_agreement/service_agreement_condition.py
+++ b/squid_py/service_agreement/service_agreement_condition.py
@@ -32,6 +32,26 @@ class Event:
     def __init__(self, event_json):
         self.values_dict = dict(event_json)
 
+    @property
+    def name(self):
+        return self.values_dict['name']
+
+    @property
+    def actor_type(self):
+        return self.values_dict['actorType']
+
+    @property
+    def handler_module_name(self):
+        return self.values_dict['handler']['moduleName']
+
+    @property
+    def handler_function_name(self):
+        return self.values_dict['handler']['functionName']
+
+    @property
+    def handler_version(self):
+        return self.values_dict['handler']['version']
+
     def as_dictionary(self):
         return self.values_dict
 

--- a/squid_py/service_agreement/service_agreement_template.py
+++ b/squid_py/service_agreement/service_agreement_template.py
@@ -176,6 +176,15 @@ class ServiceAgreementTemplate(object):
                     "functionName": "releasePayment",
                     "version": "0.1"
                   }
+                },
+                {
+                    "name": "AccessTimeout",
+                    "actorType": "consumer",
+                    "handler": {
+                        "moduleName": "paymentProcessing",
+                        "functionName": "refundPayment",
+                        "version": "0.1"
+                    }
                 }
               ],
               "dependencies": ["lockPayment"],

--- a/squid_py/service_agreement/storage.py
+++ b/squid_py/service_agreement/storage.py
@@ -10,7 +10,7 @@ def record_service_agreement(storage_path, service_agreement_id, did, service_in
         cursor.execute(
             '''CREATE TABLE IF NOT EXISTS service_agreements
                (id VARCHAR PRIMARY KEY, did VARCHAR, service_index INTEGER, 
-               price INTEGER, content_urls VARCHAR, start_time TIMESTAMP, status VARCHAR(10));'''
+                price INTEGER, content_urls VARCHAR, start_time INTEGER, status VARCHAR(10));'''
         )
         cursor.execute(
             'INSERT OR REPLACE INTO service_agreements VALUES (?,?,?,?,?,?,?)',
@@ -38,8 +38,15 @@ def get_service_agreements(storage_path, status='pending'):
     conn = sqlite3.connect(storage_path)
     try:
         cursor = conn.cursor()
-        return [row for row in
-                cursor.execute("SELECT * FROM service_agreements WHERE status='%s';" % status)]
+        return [
+            row for row in
+            cursor.execute(
+                ''' SELECT id, did, service_index, price, content_urls, start_time, status 
+                    FROM service_agreements 
+                    WHERE status=?
+                    ;''',
+                (status,))
+        ]
     finally:
         conn.close()
 

--- a/squid_py/service_agreement/storage.py
+++ b/squid_py/service_agreement/storage.py
@@ -41,10 +41,11 @@ def get_service_agreements(storage_path, status='pending'):
         return [
             row for row in
             cursor.execute(
-                ''' SELECT id, did, service_index, price, content_urls, start_time, status 
-                    FROM service_agreements 
-                    WHERE status=?
-                    ;''',
+                '''
+                SELECT id, did, service_index, price, content_urls, start_time, status
+                FROM service_agreements 
+                WHERE status=?;
+                ''',
                 (status,))
         ]
     finally:

--- a/squid_py/service_agreement/storage.py
+++ b/squid_py/service_agreement/storage.py
@@ -1,7 +1,7 @@
 import sqlite3
 
 
-def record_service_agreement(storage_path, service_agreement_id, did, status='pending'):
+def record_service_agreement(storage_path, service_agreement_id, did, service_index, price, content_urls, start_time, status='pending'):
     """ Records the given pending service agreement.
     """
     conn = sqlite3.connect(storage_path)
@@ -9,11 +9,25 @@ def record_service_agreement(storage_path, service_agreement_id, did, status='pe
         cursor = conn.cursor()
         cursor.execute(
             '''CREATE TABLE IF NOT EXISTS service_agreements
-               (id VARCHAR PRIMARY KEY, did VARCHAR, status VARCHAR(10));'''
+               (id VARCHAR PRIMARY KEY, did VARCHAR, service_index INTEGER, 
+               price INTEGER, content_urls VARCHAR, start_time TIMESTAMP, status VARCHAR(10));'''
         )
         cursor.execute(
-            'INSERT OR REPLACE INTO service_agreements VALUES (?,?,?)',
-            [service_agreement_id, did, status],
+            'INSERT OR REPLACE INTO service_agreements VALUES (?,?,?,?,?,?,?)',
+            [service_agreement_id, did, service_index, price, content_urls, start_time, status],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def update_service_agreement_status(storage_path, service_agreement_id, status='pending'):
+    conn = sqlite3.connect(storage_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            'UPDATE service_agreements SET status=? WHERE id=?',
+            (status, service_agreement_id),
         )
         conn.commit()
     finally:

--- a/squid_py/utils/utilities.py
+++ b/squid_py/utils/utilities.py
@@ -1,6 +1,7 @@
 import uuid
 import time
 from collections import namedtuple
+from datetime import datetime
 from threading import Thread
 
 from eth_utils import big_endian_to_int
@@ -80,15 +81,18 @@ def get_network_name(web3):
     return switcher.get(network_id, 'development')
 
 
-def watch_event(contract_name, event_name, callback, interval, fromBlock=0, toBlock='latest',
+def watch_event(contract_name, event_name, callback, interval,
+                start_time, timeout=None, timeout_callback=None,
+                fromBlock=0, toBlock='latest',
                 filters=None, num_confirmations=12):
+
     event_filter = install_filter(
         contract_name, event_name, fromBlock, toBlock, filters
     )
     event_filter.poll_interval = interval
     Thread(
         target=watcher,
-        args=(event_filter, callback),
+        args=(event_filter, callback, start_time, timeout, timeout_callback),
         kwargs={'num_confirmations': num_confirmations},
         daemon=True,
     ).start()
@@ -104,7 +108,8 @@ def install_filter(contract, event_name, fromBlock=0, toBlock='latest', filters=
     return event_filter
 
 
-def watcher(event_filter, callback, num_confirmations=12):
+def watcher(event_filter, callback, start_time, timeout, timeout_callback, num_confirmations=12):
+    timed_out = False
     while True:
         try:
             events = event_filter.get_new_entries()
@@ -113,6 +118,7 @@ def watcher(event_filter, callback, num_confirmations=12):
             print('Got error grabbing keeper events: ', str(err))
             events = []
 
+        processed = False
         for event in events:
             if num_confirmations > 0:
                 Thread(
@@ -129,9 +135,22 @@ def watcher(event_filter, callback, num_confirmations=12):
                 ).start()
             else:
                 callback(event)
+            processed = True
+
+        if processed:
+            break
 
         # always take a rest
         time.sleep(0.1)
+        if timeout_callback:
+            now = int(datetime.now().timestamp())
+            if (start_time + timeout) < now:
+                # timeout exceeded, break out of this loop and trigger the timeout callback
+                timed_out = True
+                break
+
+    if timed_out and timeout_callback:
+        timeout_callback(start_time, timeout, int(datetime.now().timestamp()))
 
 
 def await_confirmations(event_filter, block_number, block_hash, num_confirmations, callback, event):

--- a/squid_py/utils/utilities.py
+++ b/squid_py/utils/utilities.py
@@ -150,7 +150,7 @@ def watcher(event_filter, callback, start_time, timeout, timeout_callback, num_c
                 break
 
     if timed_out and timeout_callback:
-        timeout_callback(start_time, timeout, int(datetime.now().timestamp()))
+        timeout_callback((start_time, timeout, int(datetime.now().timestamp())))
 
 
 def await_confirmations(event_filter, block_number, block_hash, num_confirmations, callback, event):


### PR DESCRIPTION
## Description

Add remaining feature in squid py:
* refundPayment condition
* Fulfill and terminate agreement upon terminating condition events
* Handle timeout events
* Complete service consumption once the access permission is received

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()