### PR TITLE
When executing agreement, raise exception if signature fails verification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![banner](https://raw.githubusercontent.com/oceanprotocol/art/master/github/repo-banner%402x.png)](https://oceanprotocol.com)
+from squid_py.utils.utilities import get_purchase_endpointfrom squid_py.service_agreement.service_types import ACCESS_SERVICE_TEMPLATE_IDfrom squid_py.ddo.metadata import Metadata[![banner](https://raw.githubusercontent.com/oceanprotocol/art/master/github/repo-banner%402x.png)](https://oceanprotocol.com)
 
 # squid-py
 
@@ -39,23 +39,90 @@ Install Squid:
 pip install squid-py
 ```
 
-The entry point into the Squid functionality is the Ocean class:
+### Usage:
 
 ```python
-from squid_py.ocean import Ocean
-ocean = Ocean('config.ini')
+import os
+import time
 
-assert ocean.get_accounts()
+from squid_py import (
+    Ocean, 
+    ServiceDescriptor, 
+    ACCESS_SERVICE_TEMPLATE_ID,
+    get_service_endpoint,
+    get_purchase_endpoint,
+)
+from squid_py.ddo.metadata import Metadata
+
+# Make a new instance of Ocean
+ocean = Ocean('config.ini')  # or Ocean(config_dict)
+# You can set a specific ethereum account to use by using `ocean.set_main_account(address, password)` 
+# Ocean picks up address and password by default from the parity.address and parity.password in the config
+
+# PUBLISHER
+# Let's start by registering an asset in the Ocean network
+metadata = Metadata.get_example()
+
+# purchase and service endpoints require `brizo.url` is set in the config file 
+# or passed to Ocean instance in the config_dict.
+purchase_endpoint = get_purchase_endpoint(ocean.config)
+service_endpoint = get_service_endpoint(ocean.config)
+# define the services to include in the new asset DDO
+service_descriptor = ServiceDescriptor.access_service_descriptor(2, purchase_endpoint, service_endpoint, 900, ACCESS_SERVICE_TEMPLATE_ID)
+
+ddo = ocean.register_asset(metadata, ocean.main_account.address, service_descriptor)
+
+# Now we have an asset registered, we can verify it exists by resolving the did
+_ddo = ocean.resolve_did(ddo.did)
+# ddo and _ddo should be identical
+
+# CONSUMER
+# search for assets
+asset = ocean.search_assets_by_text('Ocean protocol')[0]
+# Need some ocean tokens to be able to purchase assets
+ocean.main_account.unlock()
+ocean.keeper.market.request_tokens(10, ocean.main_account.address)
+# Start the purchase/consume request. This will automatically make a payment from the specified account.
+service_agreement_id = ocean.sign_service_agreement(asset.did, 0, ocean.main_account.address)
+# after a short wait (seconds to minutes) the asset data files should be available in the `downloads.path` defined in config
+# wait a bit to let things happen
+time.sleep(30)
+# Asset files are saved in a folder named after the asset DID
+if os.path.exists(ocean.get_asset_folder_path(asset.did, 0)):
+    print('asset files downloaded: {}'.format(os.listdir(ocean.get_asset_folder_path(asset.did, 0))))
+
 ```
 
 ## Configuration
 
-`keeper.url` points to an Ethereum RPC client. Note that Squid learns the name of the network to work with from this client.
+```python
+config_dict = {
+    'keeper-contracts': {
+        # Point to an Ethereum RPC client. Note that Squid learns the name of the network to work with from this client.
+        'keeper.url': 'http://localhost:8545',
+        # Specify the keeper contracts artifacts folder (has the smart contracts definitions json files). When you 
+        # install the package, the artifacts are automatically picked up from the `keeper-contracts` Python 
+        # dependency unless you are using a local ethereum network.
+        'keeper.path': 'artifacts', 
+        'secret_store.url': 'http://localhost:12001',
+        'parity.url': 'http://localhost:8545',
+        'parity.address': '',
+        'parity.password': '',
+    
+    },
+    'resources': {
+        # aquarius is the metadata store. It stores the assets DDO/DID-document
+        'aquarius.url': 'http://localhost:5000',
+        # Brizo is the publisher's agent. It serves purchase and requests for both data access and compute services 
+        'brizo.url': 'http://localhost:8030',
+        # points to the local database file used for storing temporary information (for instance, pending service agreements).
+        'storage.path': 'squid_py.db',
+        # Where to store downloaded asset files
+        'downloads.path': 'consume-downloads'
+    }
+}
 
-`keeper.path` points to the folder with keeper contracts definitions. When you install the package, the artifacts are
-automatically picked up from the `keeper-contracts` Python dependency.
-
-`storage.path` points to the local database file used for storing temporary information (for instance, pending service agreements).
+```
 
 In addition to the configuration file, you may use the following environment variables (override the corresponding configuration file values):
 

--- a/squid_py/__init__.py
+++ b/squid_py/__init__.py
@@ -4,4 +4,20 @@ __version__ = '0.2.16'
 from .exceptions import (
     OceanInvalidContractAddress,
 )
-
+from .ocean import (
+    Ocean,
+    Account,
+    Asset,
+)
+from .service_agreement import (
+    ServiceTypes,
+    ServiceDescriptor,
+    ServiceFactory,
+    ServiceAgreement,
+    ServiceAgreementTemplate,
+    ACCESS_SERVICE_TEMPLATE_ID,
+)
+from .utils import (
+    get_purchase_endpoint,
+    get_service_endpoint,
+)

--- a/squid_py/exceptions.py
+++ b/squid_py/exceptions.py
@@ -32,3 +32,6 @@ class OceanDIDAlreadyExist(Exception):
 
 class OceanInvalidMetadata(Exception):
     pass
+
+class OceanInvalidServiceAgreementSignature(Exception):
+    pass

--- a/squid_py/ocean/__init__.py
+++ b/squid_py/ocean/__init__.py
@@ -1,0 +1,9 @@
+from .ocean import (
+    Ocean,
+)
+from .account import (
+    Account,
+)
+from .asset import (
+    Asset,
+)

--- a/squid_py/ocean/ocean.py
+++ b/squid_py/ocean/ocean.py
@@ -407,11 +407,6 @@ class Ocean:
         recovered_address = self._web3.eth.account.recoverHash(prefixed_hash, signature=signature)
         is_valid = (recovered_address == consumer_address)
         if not is_valid:
-            # try without the `Ethereum...` prefix
-            recovered_address = self._web3.eth.account.recoverHash(agreement_hash, signature=signature)
-            is_valid = (recovered_address == consumer_address)
-
-        if not is_valid:
             logger.warning('Agreement signature failed: agreement hash is %s', agreement_hash.hex())
 
         self._validate_conditions_keys(sa)

--- a/squid_py/service_agreement/__init__.py
+++ b/squid_py/service_agreement/__init__.py
@@ -1,0 +1,14 @@
+from .service_agreement import (
+    ServiceAgreement
+)
+from .service_agreement_template import (
+    ServiceAgreementTemplate
+)
+from .service_factory import (
+    ServiceDescriptor,
+    ServiceFactory
+)
+from .service_types import (
+    ServiceTypes,
+    ACCESS_SERVICE_TEMPLATE_ID,
+)

--- a/squid_py/service_agreement/service_agreement.py
+++ b/squid_py/service_agreement/service_agreement.py
@@ -94,7 +94,6 @@ class ServiceAgreement(object):
         """
         agreement_hash = self.get_service_agreement_hash(web3, contract_path, service_agreement_id)
         # We cannot use `web3.eth.account.signHash()` here because it requires privateKey which is not available.
-        web3.eth.account.signHash()
         return web3.eth.sign(consumer_address, agreement_hash).hex(), agreement_hash.hex()
 
     def update_conditions_keys(self, web3, contract_path):

--- a/squid_py/service_agreement/service_agreement.py
+++ b/squid_py/service_agreement/service_agreement.py
@@ -93,6 +93,8 @@ class ServiceAgreement(object):
         :return: signed_msg_hash, msg_hash
         """
         agreement_hash = self.get_service_agreement_hash(web3, contract_path, service_agreement_id)
+        # We cannot use `web3.eth.account.signHash()` here because it requires privateKey which is not available.
+        web3.eth.account.signHash()
         return web3.eth.sign(consumer_address, agreement_hash).hex(), agreement_hash.hex()
 
     def update_conditions_keys(self, web3, contract_path):

--- a/squid_py/service_agreement/service_factory.py
+++ b/squid_py/service_agreement/service_factory.py
@@ -33,7 +33,7 @@ class ServiceFactory(object):
         for i, service_desc in enumerate(service_descriptors):
             service = ServiceFactory.build_service(web3, contract_path, service_desc, did)
             # set serviceDefinitionId for each service
-            service.update_value(sa_def_key, str(i+1))
+            service.update_value(sa_def_key, str(i))
             services.append(service)
 
         return services

--- a/squid_py/utils/__init__.py
+++ b/squid_py/utils/__init__.py
@@ -6,5 +6,7 @@ from .utilities import (
     convert_to_bytes,
     convert_to_text,
     to_32byte_hex,
-    split_signature
+    split_signature,
+    get_purchase_endpoint,
+    get_service_endpoint,
 )

--- a/tests/test_ocean.py
+++ b/tests/test_ocean.py
@@ -208,7 +208,7 @@ def test_execute_agreement(publisher_ocean_instance, consumer_ocean_instance, re
     web3 = keeper.web3
     consumer_acc = consumer_ocn.main_account
     publisher_acc = publisher_ocean_instance.main_account
-    service_index = '1'
+    service_index = '0'
     did = registered_ddo.did
 
     # sign agreement


### PR DESCRIPTION
Implement some enhancements:
* Raise error when agreement signature fails verification
* Verify signature now tries to verify with the ethereum prefixed agreement hash first. If this fails, it verifies using the plain agreement hash with no prefix.
* Expose ocean and other components to the top level to allow using short imports