### PR TITLE
move unlock from contract-base to account

### DIFF
--- a/squid_py/keeper/contract_base.py
+++ b/squid_py/keeper/contract_base.py
@@ -55,12 +55,6 @@ class ContractBase(object):
 
         return concise_contract, contract, address
 
-    def unlock_account(self, account):
-        if account.password:
-            return self.web3.personal.unlockAccount(account.address, account.password)
-
-        return None
-
     def to_checksum_address(self, address):
         """Validate the address provided."""
         return self.web3.toChecksumAddress(address)

--- a/squid_py/keeper/didregistry.py
+++ b/squid_py/keeper/didregistry.py
@@ -80,7 +80,7 @@ class DIDRegistry(ContractBase):
         if account is None:
             raise ValueError('You must provide an account to use to register a DID')
 
-        self.unlock_account(account)
+        account.unlock()
         transaction = self.register_attribute(did_source_id, value_type, key, value, account.address)
         receipt = self.get_tx_receipt(transaction)
         return receipt

--- a/squid_py/keeper/service_agreement.py
+++ b/squid_py/keeper/service_agreement.py
@@ -28,7 +28,7 @@ class ServiceAgreement(ContractBase):
             assert i < len(contracts_addresses), ''
         assert isinstance(fulfillment_operator, int) and fulfillment_operator >= 0, ''
 
-        self.unlock_account(owner_account)
+        owner_account.unlock()
         service_bytes = Web3.toHex(Web3.sha3(text=service_description))
         tx_hash = self.contract_concise.setupAgreementTemplate(
             template_id,
@@ -46,7 +46,7 @@ class ServiceAgreement(ContractBase):
         assert len(hashes) == len(timeouts), ''
         assert did_id.startswith('0x'), ''
 
-        self.unlock_account(publisher_account)
+        publisher_account.unlock()
         tx_hash = self.contract_concise.executeAgreement(
             template_id, signature, consumer, hashes, timeouts, service_agreement_id, did_id,
             transact={'from': publisher_account.address, 'gas': DEFAULT_GAS_LIMIT}
@@ -54,11 +54,11 @@ class ServiceAgreement(ContractBase):
         return self.get_tx_receipt(tx_hash)
 
     def fulfill_agreement(self, service_agreement_id, from_account):
-        self.unlock_account(from_account)
+        from_account.unlock()
         return self.contract_concise.fulfillAgreement(service_agreement_id)
 
     def revoke_agreement_template(self, template_id, owner_account):
-        self.unlock_account(owner_account)
+        owner_account.unlock()
         return self.contract_concise.revokeAgreementTemplate(template_id)
 
     def get_template_status(self, sa_template_id):

--- a/squid_py/keeper/token.py
+++ b/squid_py/keeper/token.py
@@ -8,9 +8,6 @@ class Token(ContractBase):
     def __init__(self, web3, contract_path):
         ContractBase.__init__(self, web3, contract_path, 'OceanToken')
 
-    def get_ether_balance(self, account_address, block_identifier='latest'):
-        return self.web3.eth.getBalance(account_address, block_identifier)
-
     def get_token_balance(self, account_address):
         """Retrieve the amount of tokens of an account address"""
         return self.contract_concise.balanceOf(account_address)
@@ -23,5 +20,5 @@ class Token(ContractBase):
         if not self.web3.isChecksumAddress(spender_address):
             spender_address = self.web3.toChecksumAddress(spender_address)
 
-        self.unlock_account(from_account)
+        from_account.unlock()
         return self.contract_concise.approve(spender_address, price, transact={'from': from_account.address})

--- a/squid_py/ocean/account.py
+++ b/squid_py/ocean/account.py
@@ -18,6 +18,7 @@ class Account:
     def unlock(self):
         if self.password:
             return self.keeper.web3.personal.unlockAccount(self.address, self.password)
+        return False
 
     def request_tokens(self, amount):
         self.unlock()

--- a/squid_py/ocean/account.py
+++ b/squid_py/ocean/account.py
@@ -8,7 +8,7 @@ class Account:
         """
         Hold account address, and update balances of Ether and Ocean token
 
-        :param keeper: The instantiated Keeper
+        :param keeper: The keeper instance
         :param address: The address of this account
         """
         self.keeper = keeper
@@ -16,20 +16,12 @@ class Account:
         self.password = password
 
     def unlock(self):
-        return self.keeper.market.unlock_account(self)
+        if self.password:
+            return self.keeper.web3.personal.unlockAccount(self.address, self.password)
 
     def request_tokens(self, amount):
         self.unlock()
         return self.keeper.market.request_tokens(amount, self.address)
-
-    def get_balance(self):
-        return Balance(self.ether_balance, self.ocean_balance)
-
-    def get_ether_balance(self):
-        return self.ether_balance
-
-    def get_ocean_balance(self):
-        return self.ocean_balance
 
     @property
     def balance(self):
@@ -41,7 +33,7 @@ class Account:
         Call the Token contract method .web3.eth.getBalance()
         :return: Ether balance, int
         """
-        return self.keeper.token.get_ether_balance(self.address)
+        return self.keeper.web3.eth.getBalance(self.address, block_identifier='latest')
 
     @property
     def ocean_balance(self):

--- a/squid_py/ocean/ocean.py
+++ b/squid_py/ocean/ocean.py
@@ -184,6 +184,7 @@ class Ocean:
         ddo = DDO(did)
 
         # Add public key and authentication
+        publisher.unlock()
         pub_key, auth = make_public_key_and_authentication(did, publisher.address, self._web3)
         ddo.add_public_key(pub_key)
         ddo.add_authentication(auth, PUBLIC_KEY_TYPE_RSA)

--- a/squid_py/ocean/ocean.py
+++ b/squid_py/ocean/ocean.py
@@ -156,22 +156,20 @@ class Ocean:
         else:
             return [Asset.from_ddo_dict(i) for i in self.metadata_store.query_search(query)]
 
-    def register_asset(self, metadata, publisher_address, service_descriptors, threshold=None):
+    def register_asset(self, metadata, publisher, service_descriptors):
         """
         Register an asset in both the keeper's DIDRegistry (on-chain) and in the Metadata store (Aquarius)
 
         :param metadata: dict conforming to the Metadata accepted by Ocean Protocol.
-        :param publisher_address: Account of the publisher registering this asset
+        :param publisher: Account of the publisher registering this asset
         :param service_descriptors: list of ServiceDescriptor tuples of length 2. The first item must be one of ServiceTypes and the second
             item is a dict of parameters and values required by the service
-        :param threshold: a secret store setting, currently not in use
         :return: DDO instance
         """
-        assert publisher_address and self._web3.isChecksumAddress(publisher_address), 'Invalid publisher address "%s"' % publisher_address
-        assert publisher_address in self.accounts, 'Unrecognized publisher address %s' % publisher_address
         assert isinstance(metadata, dict), 'Expected metadata of type dict, got "%s"' % type(metadata)
         if not metadata or not Metadata.validate(metadata):
-            raise OceanInvalidMetadata('Metadata seems invalid. Please make sure the required metadata values are filled in.')
+            raise OceanInvalidMetadata('Metadata seems invalid. '
+                                       'Please make sure the required metadata values are filled in.')
 
         asset_id = generate_prefixed_id()
         # Check if it's already registered first!
@@ -186,7 +184,7 @@ class Ocean:
         ddo = DDO(did)
 
         # Add public key and authentication
-        pub_key, auth = make_public_key_and_authentication(did, publisher_address, self._web3)
+        pub_key, auth = make_public_key_and_authentication(did, publisher.address, self._web3)
         ddo.add_public_key(pub_key)
         ddo.add_authentication(auth, PUBLIC_KEY_TYPE_RSA)
 
@@ -200,7 +198,8 @@ class Ocean:
         if content_urls_encrypted:
             metadata_copy['base']['contentUrls'] = [content_urls_encrypted]
         else:
-            raise AssertionError('Encrypting the contentUrls failed. Make sure the secret store is setup properly in your config file.')
+            raise AssertionError('Encrypting the contentUrls failed. '
+                                 'Make sure the secret store is setup properly in your config file.')
 
         # DDO url and `Metadata` service
         ddo_service_endpoint = self.metadata_store.get_service_endpoint(did)
@@ -231,7 +230,7 @@ class Ocean:
             Web3.toBytes(hexstr=asset_id),
             key=Web3.sha3(text='Metadata'),
             url=ddo_service_endpoint,
-            account=self.accounts[publisher_address]
+            account=publisher
         )
 
         return ddo

--- a/tests/test_ocean.py
+++ b/tests/test_ocean.py
@@ -82,8 +82,8 @@ def test_token_request(publisher_ocean_instance, consumer_ocean_instance):
     aquarius_current_ocean = pub_ocn.main_account.ocean_balance
 
     # Confirm balance changes
-    assert pub_ocn.main_account.get_balance().eth == aquarius_current_eth
-    assert pub_ocn.main_account.get_balance().ocn == aquarius_current_ocean
+    assert pub_ocn.main_account.balance.eth == aquarius_current_eth
+    assert pub_ocn.main_account.balance.ocn == aquarius_current_ocean
     # assert aquarius_current_eth < aquarius_start_eth
     # assert aquarius_current_ocean == aquarius_start_ocean + amount
 
@@ -101,16 +101,15 @@ def test_register_asset(publisher_ocean_instance):
     ##########################################################
     # Setup account
     ##########################################################
-    publisher_acct = publisher_ocean_instance.main_account
-    publisher_address = publisher_acct.address
+    publisher = publisher_ocean_instance.main_account
 
     # ensure Ocean token balance
-    if publisher_acct.ocean_balance == 0:
-        rcpt = publisher_acct.request_tokens(200)
+    if publisher.ocean_balance == 0:
+        rcpt = publisher.request_tokens(200)
         publisher_ocean_instance._web3.eth.waitForTransactionReceipt(rcpt)
 
     # You will need some token to make this transfer!
-    assert publisher_acct.ocean_balance > 0
+    assert publisher.ocean_balance > 0
 
     ##########################################################
     # Create an Asset with valid metadata
@@ -129,7 +128,7 @@ def test_register_asset(publisher_ocean_instance):
     # Register using high-level interface
     ##########################################################
     service_descriptors = [ServiceDescriptor.access_service_descriptor(asset_price, '/purchaseEndpoint', '/serviceEndpoint', 600, ('0x%s' % generate_new_id()))]
-    publisher_ocean_instance.register_asset(asset.metadata, publisher_address, service_descriptors)
+    publisher_ocean_instance.register_asset(asset.metadata, publisher, service_descriptors)
 
 
 def test_resolve_did(publisher_ocean_instance):
@@ -137,7 +136,7 @@ def test_resolve_did(publisher_ocean_instance):
     metadata = Metadata.get_example()
     publisher = publisher_ocean_instance.main_account
     original_ddo = publisher_ocean_instance.register_asset(
-        metadata, publisher.address,
+        metadata, publisher,
         [ServiceDescriptor.access_service_descriptor(7, '/dummy/url', '/service/endpoint', 3, ('0x%s' % generate_new_id()))]
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,7 +107,7 @@ def get_registered_ddo(ocean_instance):
     purchase_endpoint = get_purchase_endpoint(config)
     service_endpoint = get_service_endpoint(config)
     ddo = ocean_instance.register_asset(
-        Metadata.get_example(), ocean_instance.main_account.address,
+        Metadata.get_example(), ocean_instance.main_account,
         [ServiceDescriptor.access_service_descriptor(7, purchase_endpoint, service_endpoint, 360, template_id)]
     )
 


### PR DESCRIPTION
## Description

Moved unlock under the Account class

- `ocean.register_asset` now takes an `Account`, not an `address` as input param
- no more `contract.unlock_account`, but `account.unlock` instead

## Is this PR related with an open issue?

Related to Issue #158

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

