### PR TITLE
Install all requirements to build docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,1 @@
-Sphinx
-sphinx-rtd-theme
-sphinxcontrib-apidoc
+-e ..[docs]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ dev_requirements = [
 
 docs_requirements = [
     'Sphinx',
-    'sphinx-rtd-theme',
     'sphinxcontrib-apidoc',
 ]
 
@@ -75,6 +74,7 @@ setup(
     extras_require={
         'test': test_requirements,
         'dev': dev_requirements + test_requirements + docs_requirements,
+        'docs': docs_requirements,
     },
     install_requires=install_requirements,
     license="Apache Software License 2.0",


### PR DESCRIPTION
The `docs/requirements.txt` file used by ReadTheDocs.org didn't install enough requirements, and that was causing warnings over there like:

```text
WARNING: autodoc: failed to import module 'squid_py'; the following exception was raised:
No module named 'Crypto'
```

Unfortunately, the end result was that the leaf pages were blank. Not good!

I think this pull request should get ReadTheDocs installing all the Python packages needed to build the docs (`install_requirements` + `docs_requirements` in the main `setup.py`). There's only one way to be sure though: merge this pull request and see what happens on ReadTheDocs.

Bonus: I also removed the `sphinx-rtd-theme` package because the squid-py docs now use the Alabaster theme, which is included by default.