### PR TITLE
Try another way to install all reqs for RTD

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,13 @@
--e ..[docs]
+# Based on install_requirements in setup.py:
+coloredlogs
+eciespy
+keeper-contracts==0.5.1
+pyopenssl
+PyJWT
+PyYAML
+web3==4.5.0
+ocean-secret-store-client==0.0.1
+#
+# Based on docs_requirements in setup.py:
+Sphinx
+sphinxcontrib-apidoc

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ setup(
     extras_require={
         'test': test_requirements,
         'dev': dev_requirements + test_requirements + docs_requirements,
-        'docs': docs_requirements,
     },
     install_requires=install_requirements,
     license="Apache Software License 2.0",


### PR DESCRIPTION
This is a follow-up on pull request #200, which didn't work. Read that pull request to understand the motivation.

This time around I'm not doing anything fancy. I'm just manually copying the `install_requirements` and `docs_requirement` into `docs/requirements.txt`. I don't like that solution because it opens the door to that file getting out of sync, but I suppose that's better than having empty leaf pages in the docs.
