### PR TITLE
Revive 'make lint' using PyLint (not Flake8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
+lint: ## check style with PyLint
+	pylint --errors-only squid_py tests
+
 test: ## run tests quickly with the default Python
 	py.test
 


### PR DESCRIPTION
This brings back the `make lint` subcommand using PyLint rather than Flake8.