### PR TITLE
Add dependency injection test utilities and some sample unit tests

### DIFF
--- a/squid_py/keeper/contract_base.py
+++ b/squid_py/keeper/contract_base.py
@@ -14,13 +14,15 @@ logger = logging.getLogger('keeper')
 class ContractBase(object):
     """Base class for all contract objects."""
 
-    def __init__(self, contract_name):
+    def __init__(self, contract_name, dependencies={}):
 
         self.name = contract_name
 
-        from squid_py.keeper.contract_handler import ContractHandler
-        self.contract_concise = ContractHandler.get_concise_contract(contract_name)
-        self.contract = ContractHandler.get(contract_name)
+        if 'ContractHandler' not in dependencies:
+            from squid_py.keeper.contract_handler import ContractHandler
+            dependencies['ContractHandler'] = ContractHandler
+        self.contract_concise = dependencies['ContractHandler'].get_concise_contract(contract_name)
+        self.contract = dependencies['ContractHandler'].get(contract_name)
 
         logger.debug(f'Loaded {self}')
 

--- a/squid_py/keeper/contract_base_test.py
+++ b/squid_py/keeper/contract_base_test.py
@@ -1,0 +1,13 @@
+from unittest.mock import Mock, MagicMock
+from tests.resources.tiers import unit_test
+from tests.resources.dependencies import inject_dependencies
+from .contract_base import ContractBase
+
+@unit_test
+def test_to_checksum_address():
+    ContractHandler = Mock()
+    web3 = Mock()
+    web3.toChecksumAddress = MagicMock(return_value='checksum address!')
+    with inject_dependencies(ContractBase, 'TestContract', dependencies={'ContractHandler': ContractHandler, 'web3': web3}) as contract_base:
+        assert contract_base.to_checksum_address('bla') == 'checksum address!'
+        web3.toChecksumAddress.assert_called_with('bla')

--- a/squid_py/keeper/market_test.py
+++ b/squid_py/keeper/market_test.py
@@ -1,0 +1,15 @@
+from unittest.mock import Mock, MagicMock
+from tests.resources.tiers import unit_test
+from .market import Market
+
+@unit_test
+def test_check_asset():
+    contract = Mock()
+    contract_consise = Mock()
+    contract_consise.checkAsset = MagicMock(return_value='bla')
+    ContractHandler = Mock()
+    ContractHandler.get_concise = lambda name: contract if name == 'OceanMarket' else None
+    ContractHandler.get_concise_contract = lambda name: contract_consise if name == 'OceanMarket' else None
+    market = Market('OceanMarket', dependencies={'ContractHandler': ContractHandler})
+    assert market.check_asset('deadbeef') == 'bla'
+    contract_consise.checkAsset.assert_called_with(b'\xde\xad\xbe\xef')

--- a/tests/resources/dependencies.py
+++ b/tests/resources/dependencies.py
@@ -1,0 +1,24 @@
+from inspect import signature
+from contextlib import contextmanager
+from squid_py.keeper.web3_provider import Web3Provider
+
+@contextmanager
+def inject_dependencies(klass, *args, **kwargs):
+    dependencies = kwargs.pop('dependencies', {})
+    if 'dependencies' in signature(klass).parameters:
+        kwargs['dependencies'] = dependencies
+
+    to_restore = []
+    def patch_provider(object, property, mock):
+        to_restore.append((object, property, getattr(object, property)))
+        setattr(object, property, mock)
+    def maybe_patch_provider(object, property, name):
+        if name in dependencies:
+            patch_provider(object, property, dependencies[name])
+
+    maybe_patch_provider(Web3Provider, '_web3', 'web3')
+    try:
+        yield klass(*args, **kwargs)
+    finally:
+        for (object, property, value) in to_restore:
+            setattr(object, property, value)


### PR DESCRIPTION
Test utilities for dependency injection as mentioned in #235 and two sample unit tests. One shows how to pass dependencies to class, the other one shows how to use the `inject_dependencies` context manager to safely patch the Web3Provider during a unit test.