### PR TITLE
Support asset providers (keeper v0.8.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
 before_install:
   - git clone https://github.com/oceanprotocol/barge
   - cd barge
-  - export KEEPER_VERSION=v0.8.5
+  - export KEEPER_VERSION=v0.8.7
   - export KEEPER_OWNER_ROLE_ADDRESS="0x00bd138abd70e2f00903268f3db08f2d25677c9e"
   - bash -x start_ocean.sh --latest --no-brizo --no-pleuston --local-spree-node 2>&1 > start_ocean.log &
   - cd ..

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('HISTORY.md') as history_file:
 # or pip install -e .
 install_requirements = [
     'coloredlogs',
-    'keeper-contracts==0.8.6',
+    'keeper-contracts==0.8.7',
     'pyopenssl',
     'PyJWT',  # not jwt
     'PyYAML==4.2b4',

--- a/squid_py/keeper/didregistry.py
+++ b/squid_py/keeper/didregistry.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 import logging
+from collections import namedtuple
 from urllib.parse import urlparse
 
 from web3 import Web3
@@ -13,6 +14,11 @@ from squid_py.keeper.contract_base import ContractBase
 
 logger = logging.getLogger(__name__)
 
+DIDRegisterValues = namedtuple(
+    'DIDRegisterValues',
+    ('owner', 'last_checksum', 'last_updated_by', 'block_number_updated', 'providers')
+)
+
 
 class DIDRegistry(ContractBase):
     """Class to register and update Ocean DID's."""
@@ -20,23 +26,25 @@ class DIDRegistry(ContractBase):
 
     CONTRACT_NAME = 'DIDRegistry'
 
-    def register(self, did_source, checksum, url=None, account=None):
+    def register(self, did, checksum, url, account, providers=None):
         """
         Register or update a DID on the block chain using the DIDRegistry smart contract.
 
-        :param did_source: DID to register/update, can be a 32 byte or hexstring
+        :param did: DID to register/update, can be a 32 byte or hexstring
         :param checksum: hex str hash of TODO
         :param url: URL of the resolved DID
         :param account: instance of Account to use to register/update the DID
+        :param providers: list of addresses of providers to be allowed to serve the asset and play
+            a part in creating and fulfilling service agreements
         :return: Receipt
         """
 
-        did_source_id = did_to_id_bytes(did_source)
+        did_source_id = did_to_id_bytes(did)
         if not did_source_id:
-            raise ValueError(f'{did_source} must be a valid DID to register')
+            raise ValueError(f'{did} must be a valid DID to register')
 
         if not urlparse(url):
-            raise ValueError(f'Invalid URL {url} to register for DID {did_source}')
+            raise ValueError(f'Invalid URL {url} to register for DID {did}')
 
         if checksum is None:
             checksum = Web3.toBytes(0)
@@ -47,23 +55,28 @@ class DIDRegistry(ContractBase):
         if account is None:
             raise ValueError('You must provide an account to use to register a DID')
 
-        transaction = self.register_attribute(did_source_id, checksum, url,
-                                              account)
+        transaction = self._register_attribute(
+            did_source_id, checksum, url, account, providers or []
+        )
         receipt = self.get_tx_receipt(transaction)
         return receipt
 
-    def register_attribute(self, did_hash, checksum, value, account):
+    def _register_attribute(self, did, checksum, value, account, providers):
         """Register an DID attribute as an event on the block chain.
 
-        :param did_hash: 32 byte string/hex of the DID
+        :param did: 32 byte string/hex of the DID
         :param checksum: checksum of the ddo, hex str
         :param value: url for resolve the did, str
         :param account: account owner of this DID registration record
+        :param providers: list of providers addresses
         """
+        assert isinstance(providers, list), ''
+        assert did and did.startswith('0x') and len(did) == 65, f'Invalid did {did}'
         return self.send_transaction(
             'registerAttribute',
-            (did_hash,
+            (did,
              checksum,
+             providers,
              value),
             transact={'from': account.address,
                       'passphrase': account.password}
@@ -81,6 +94,41 @@ class DIDRegistry(ContractBase):
         :return: ethereum address, hex str
         """
         return self.contract_concise.getDIDOwner(did)
+
+    def add_provider(self, did, provider_address, account):
+        tx_hash = self.send_transaction(
+            'addDIDProvider',
+            (did,
+             provider_address),
+            transact={'from': account.address,
+                      'passphrase': account.password}
+        )
+        return self.get_tx_receipt(tx_hash)
+
+    def remove_provider(self, did, provider_address, account):
+        tx_hash = self.send_transaction(
+            'removeDIDProvider',
+            (did,
+             provider_address),
+            transact={'from': account.address,
+                      'passphrase': account.password}
+        )
+        return self.get_tx_receipt(tx_hash)
+
+    def get_did_providers(self, did):
+        """
+        Return the list providers registered on-chain for the given did.
+
+        :param did: hex str the id of an asset on-chain
+        :return:
+            list of addresses
+            None if asset has no registerd providers
+        """
+        register_values = self.contract_concise.getDIDRegister(did)
+        if register_values and len(register_values) == 5:
+            return DIDRegisterValues(*register_values).providers
+
+        return None
 
     def get_registered_attribute(self, did_bytes):
         """

--- a/squid_py/keeper/didregistry.py
+++ b/squid_py/keeper/didregistry.py
@@ -71,7 +71,6 @@ class DIDRegistry(ContractBase):
         :param providers: list of providers addresses
         """
         assert isinstance(providers, list), ''
-        assert did and did.startswith('0x') and len(did) == 65, f'Invalid did {did}'
         return self.send_transaction(
             'registerAttribute',
             (did,

--- a/squid_py/keeper/event_listener.py
+++ b/squid_py/keeper/event_listener.py
@@ -74,7 +74,6 @@ class EventListener(object):
 
         return None
 
-    # @staticmethod
     def watch_one_event(self, event_filter, callback, timeout_callback, timeout, args,
                         start_time=None):
         """

--- a/squid_py/ocean/ocean.py
+++ b/squid_py/ocean/ocean.py
@@ -15,6 +15,7 @@ from squid_py.log import setup_logging
 from squid_py.ocean.ocean_accounts import OceanAccounts
 from squid_py.ocean.ocean_agreements import OceanAgreements
 from squid_py.ocean.ocean_assets import OceanAssets
+from squid_py.ocean.ocean_providers import OceanProviders
 from squid_py.ocean.ocean_secret_store import OceanSecretStore
 from squid_py.ocean.ocean_services import OceanServices
 from squid_py.ocean.ocean_templates import OceanTemplates
@@ -86,6 +87,8 @@ class Ocean:
             self._config
         )
         self.services = OceanServices()
+        self.ocean_providers = OceanProviders(self._keeper, self._did_resolver, self._config)
+
         # Verify keeper contracts
         Diagnostics.verify_contracts()
         # Diagnostics.check_deployed_agreement_templates()

--- a/squid_py/ocean/ocean_assets.py
+++ b/squid_py/ocean/ocean_assets.py
@@ -53,7 +53,7 @@ class OceanAssets:
             self._config.secret_store_url, self._config.parity_url, account
         )
 
-    def create(self, metadata, publisher_account, service_descriptors=None):
+    def create(self, metadata, publisher_account, service_descriptors=None, providers=None):
         """
         Register an asset in both the keeper's DIDRegistry (on-chain) and in the Metadata store (
         Aquarius).
@@ -63,6 +63,8 @@ class OceanAssets:
         :param service_descriptors: list of ServiceDescriptor tuples of length 2.
             The first item must be one of ServiceTypes and the second
             item is a dict of parameters and values required by the service
+        :param providers: list of addresses of providers of this asset (a provider is
+            an ethereum account that is authorized to provide asset services)
         :return: DDO instance
         """
         assert isinstance(metadata, dict), f'Expected metadata of type dict, got {type(metadata)}'
@@ -172,7 +174,8 @@ class OceanAssets:
             did,
             checksum=Web3Provider.get_web3().sha3(text=metadata_copy['base']['checksum']),
             url=ddo_service_endpoint,
-            account=publisher_account
+            account=publisher_account,
+            providers=providers
         )
         logger.info(f'DDO with DID {did} successfully registered on chain.')
         return ddo

--- a/squid_py/ocean/ocean_providers.py
+++ b/squid_py/ocean/ocean_providers.py
@@ -1,0 +1,16 @@
+class OceanProviders:
+    """Ocean assets class."""
+
+    def __init__(self, keeper, did_resolver, config):
+        self._keeper = keeper
+        self._did_resolver = did_resolver
+        self._config = config
+
+    def add(self, did, provider_address, account):
+        return self._keeper.did_registry.add_provider(did, provider_address, account)
+
+    def remove(self, did, provider_address, account):
+        return self._keeper.did_registry.remove_provider(did, provider_address, account)
+
+    def list(self, did):
+        return self._keeper.did_registry.get_did_providers(did)

--- a/tests/agreements/test_agreements.py
+++ b/tests/agreements/test_agreements.py
@@ -23,7 +23,8 @@ def setup_things():
         ddo.did,
         checksum=Web3Provider.get_web3().sha3(text=ddo.metadata['base']['checksum']),
         url='aquarius:5000',
-        account=publisher_acc
+        account=publisher_acc,
+        providers=None
     )
 
     registered_ddo = ddo

--- a/tests/did_resolver/test_didresolver.py
+++ b/tests/did_resolver/test_didresolver.py
@@ -53,11 +53,11 @@ def test_did_registry_no_account_provided():
         did_registry.register(did_test, url=value_test)
     # No account provided
     with pytest.raises(ValueError):
-        did_registry.register(did_test, did_test, url=value_test)
+        did_registry.register(did_test, did_test, url=value_test, account=None)
 
     # Invalide key field provided
     with pytest.raises(ValueError):
-        did_registry.register(did_test, checksum_test, url=value_test)
+        did_registry.register(did_test, checksum_test, url=value_test, account=None)
 
 
 @e2e_test


### PR DESCRIPTION
* Support setting asset providers and allow providers to handle service agreements.
https://github.com/oceanprotocol/keeper-contracts/issues/434
* Keeper v0.8.7