### PR TITLE
Update assets.order to use agreements.create instead of agreements.send.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
 before_install:
   - git clone https://github.com/oceanprotocol/barge
   - cd barge
-  - export KEEPER_VERSION=v0.9.1
+  - export KEEPER_VERSION=latest
   - export AQUARIUS_VERSION=v0.2.2
   - bash -x start_ocean.sh --latest --no-brizo --no-pleuston --local-spree-node 2>&1 > start_ocean.log &
   - cd ..

--- a/examples/buy_asset.py
+++ b/examples/buy_asset.py
@@ -68,7 +68,7 @@ def buy_asset():
     logging.info('placed order: %s, %s', ddo.did, agreement_id)
     i = 0
     while ocn.agreements.is_access_granted(
-            agreement_id, ddo.did, consumer_account.address) is not True and i < 30:
+            agreement_id, ddo.did, consumer_account.address) is not True and i < 60:
         time.sleep(1)
         i += 1
 

--- a/squid_py/ocean/ocean_agreements.py
+++ b/squid_py/ocean/ocean_agreements.py
@@ -124,7 +124,8 @@ class OceanAgreements:
         )
 
     def create(self, did, service_definition_id, agreement_id,
-               service_agreement_signature, consumer_address, account):
+               service_agreement_signature, consumer_address,
+               account, auto_consume=False):
         """
         Execute the service agreement on-chain using keeper's ServiceAgreement contract.
 
@@ -144,6 +145,7 @@ class OceanAgreements:
         :param consumer_address: ethereum account address of consumer, hex str
         :param account: Account instance creating the agreement. Can be either the
             consumer, publisher or provider
+        :param auto_consume: bool
         :return: dict the `executeAgreement` transaction receipt
         """
         assert consumer_address and Web3Provider.get_web3().isChecksumAddress(
@@ -233,7 +235,7 @@ class OceanAgreements:
                     asset.encrypted_files,
                     account,
                     condition_ids,
-                    None
+                    self._asset_consumer.download if auto_consume else None
                 )
 
             else:

--- a/squid_py/ocean/ocean_assets.py
+++ b/squid_py/ocean/ocean_assets.py
@@ -256,11 +256,7 @@ class OceanAssets:
 
     def order(self, did, service_definition_id, consumer_account, auto_consume=False):
         """
-        Sign service agreement.
-
-        Sign the service agreement defined in the service section identified
-        by `service_definition_id` in the ddo and send the signed agreement to the purchase endpoint
-        associated with this service.
+        Place order by directly creating an SEA (agreement) on-chain.
 
         :param did: str starting with the prefix `did:op:` and followed by the asset id which is
         a hex str
@@ -268,21 +264,20 @@ class OceanAssets:
         service in the DDO (DID document)
         :param consumer_account: Account instance of the consumer
         :param auto_consume: boolean
-        :return: tuple(agreement_id, signature) the service agreement id (can be used to query
-            the keeper-contracts for the status of the service agreement) and signed agreement hash
+        :return: agreement_id the service agreement id (can be used to query
+            the keeper-contracts for the status of the service agreement)
         """
         assert consumer_account.address in self._keeper.accounts, f'Unrecognized consumer ' \
             f'address `consumer_account`'
 
-        agreement_id, signature = self._agreements.prepare(
-            did, service_definition_id, consumer_account
-        )
+        agreement_id = self._agreements.new()
         logger.debug(f'about to request create agreement: {agreement_id}')
-        self._agreements.send(
+        self._agreements.create(
             did,
-            agreement_id,
             service_definition_id,
-            signature,
+            agreement_id,
+            None,
+            consumer_account.address,
             consumer_account,
             auto_consume=auto_consume
         )

--- a/tests/assets/test_asset.py
+++ b/tests/assets/test_asset.py
@@ -168,7 +168,7 @@ def test_assets_consumed(publisher_ocean_instance, consumer_ocean_instance):
 
     i = 0
     while ocn.agreements.is_access_granted(
-            agreement_id, ddo.did, acct.address) is not True and i < 30:
+            agreement_id, ddo.did, acct.address) is not True and i < 60:
         time.sleep(1)
         i += 1
 

--- a/tests/resources/mocks/brizo_mock.py
+++ b/tests/resources/mocks/brizo_mock.py
@@ -3,22 +3,68 @@
 
 import os
 
+from eth_utils import add_0x_prefix
+
 from squid_py import ConfigProvider
+from squid_py.agreements.register_service_agreement import register_service_agreement_publisher
+from squid_py.agreements.service_agreement import ServiceAgreement
+from squid_py.agreements.service_types import ServiceTypes
 from squid_py.brizo.brizo import Brizo
+from squid_py.did import id_to_did, did_to_id
+from squid_py.keeper import Keeper
+from squid_py.keeper.web3_provider import Web3Provider
 
 
 class BrizoMock(object):
     def __init__(self, ocean_instance=None, account=None):
-        self.ocean_instance = ocean_instance
         if not ocean_instance:
             from tests.resources.helper_functions import get_publisher_ocean_instance
-            self.ocean_instance = get_publisher_ocean_instance(
+            ocean_instance = get_publisher_ocean_instance(
                 init_tokens=False, use_ss_mock=False, use_brizo_mock=False
             )
+
+        self.ocean_instance = ocean_instance
         self.account = account
         if not account:
             from tests.resources.helper_functions import get_publisher_account
             self.account = get_publisher_account(ConfigProvider.get_config())
+
+        ocean_instance.agreements.subscribe_events(
+            self.account.address, self._handle_agreement_created)
+
+    def _handle_agreement_created(self, event, *_):
+        if not event or not event.args:
+            return
+
+        # print(f'Start handle_agreement_created: event_args={event.args}')
+        config = ConfigProvider.get_config()
+        ocean = self.ocean_instance
+        provider_account = self.account
+        assert provider_account.address == event.args["_accessProvider"]
+        did = id_to_did(event.args["_did"])
+        agreement_id = Web3Provider.get_web3().toHex(event.args["_agreementId"])
+
+        ddo = ocean.assets.resolve(did)
+        sa = ServiceAgreement.from_ddo(ServiceTypes.ASSET_ACCESS, ddo)
+
+        condition_ids = sa.generate_agreement_condition_ids(
+            agreement_id=agreement_id,
+            asset_id=add_0x_prefix(did_to_id(did)),
+            consumer_address=event.args["_accessConsumer"],
+            publisher_address=ddo.publisher,
+            keeper=Keeper.get_instance())
+        register_service_agreement_publisher(
+            config.storage_path,
+            event.args["_accessConsumer"],
+            agreement_id,
+            did,
+            sa,
+            sa.service_definition_id,
+            sa.get_price(),
+            provider_account,
+            condition_ids
+        )
+        # print(f'handle_agreement_created() -- done registering event listeners.')
 
     def initialize_service_agreement(self, did, agreement_id, service_definition_id,
                                      signature, account_address, purchase_endpoint):
@@ -35,7 +81,7 @@ class BrizoMock(object):
 
     @staticmethod
     def consume_service(service_agreement_id, service_endpoint, account_address, files,
-                        destination_folder, index=None):
+                        destination_folder, *_, **__):
         for f in files:
             with open(os.path.join(destination_folder, os.path.basename(f['url'])), 'w') as of:
                 of.write(f'mock data {service_agreement_id}.{service_endpoint}.{account_address}')


### PR DESCRIPTION
This completes the new consume flow in squid-py.