### PR TITLE
Bump version: 0.6.3 → 0.6.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.3
+current_version = 0.6.4
 commit = True
 tag = True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ copyright = 'squid-py contributors'
 author = 'squid-py contributors'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.3'
+release = '0.6.4'
 # The short X.Y version
 release_parts = release.split('.')  # a list
 version = release_parts[0] + '.' + release_parts[1]

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/oceanprotocol/squid-py',
-    version='0.6.3',
+    version='0.6.4',
     zip_safe=False,
 )

--- a/squid_py/__init__.py
+++ b/squid_py/__init__.py
@@ -1,5 +1,5 @@
 __author__ = """OceanProtocol"""
-__version__ = '0.6.3'
+__version__ = '0.6.4'
 
 #  Copyright 2018 Ocean Protocol Foundation
 #  SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This release supports `duero` testnet and uses the latest keeper-contracts which enables consumer to create service agreement.