### PR TITLE
remove print and do not replace it by logging.info

### DIFF
--- a/squid_py/log.py
+++ b/squid_py/log.py
@@ -31,4 +31,3 @@ def setup_logging(default_path='logging.yaml', default_level=logging.INFO, env_k
     else:
         logging.basicConfig(level=default_level)
         coloredlogs.install(level=default_level)
-        print('Using default logging settings.')


### PR DESCRIPTION
make sure one can fully disable logging on importing the module by setting

```
import squid_py.whatever
logging.getLogger().setLevel(logging.ERROR)
```