### PR TITLE
Ensure all "tags" examples are lists

### DIFF
--- a/squid_py/ddo/metadata.py
+++ b/squid_py/ddo/metadata.py
@@ -76,7 +76,7 @@ class MetadataBase(object):
         'workExample': "Text PDF",
         'inLanguage': "en",
         'categories': ["white-papers"],
-        'tags': "data exchange sharing curation bonding curve",
+        'tags': ["data exchange", "sharing", "curation", "bonding curve"],
         'price': 23,
         'files': [
             {

--- a/tests/ddo/test_ddo.py
+++ b/tests/ddo/test_ddo.py
@@ -58,7 +58,7 @@ TEST_METADATA = """
        "4d517500da0acb0d65a716f61330969334630363ce4a6a9d39691026ac7908ea" }
      ],
      "inLanguage": "en",
-     "tags": "weather, uk, 2011, temperature, humidity",
+     "tags": ["weather", "uk", "2011", "temperature", "humidity"],
      "price": 10
    },
    "curation": {

--- a/tests/resources/ddo/ddo_sa_sample.json
+++ b/tests/resources/ddo/ddo_sa_sample.json
@@ -226,7 +226,7 @@
             }
           ],
           "inLanguage": "en",
-          "tags": "weather, uk, 2011, temperature, humidity",
+          "tags": ["weather", "uk", "2011", "temperature", "humidity"],
           "price": 10,
           "checksum": "38803b9e6f04fce3fba4b124524672592264d31847182c689095a081c9e85264"
         },

--- a/tests/resources/ddo/ddo_sample1.json
+++ b/tests/resources/ddo/ddo_sample1.json
@@ -124,7 +124,7 @@
             }
           ],
           "inLanguage": "en",
-          "tags": "weather, uk, 2011, temperature, humidity",
+          "tags": ["weather", "uk", "2011", "temperature", "humidity"],
           "price": 10,
           "checksum": "38803b9e6f04fce3fba4b124524672592264d31847182c689095a081c9e85264"
         },

--- a/tests/resources/ddo/ddo_sample2.json
+++ b/tests/resources/ddo/ddo_sample2.json
@@ -84,7 +84,7 @@
             }
           ],
           "inLanguage": "en",
-          "tags": "weather, uk, 2011, temperature, humidity",
+          "tags": ["weather", "uk", "2011", "temperature", "humidity"],
           "price": 10,
           "checksum": "38803b9e6f04fce3fba4b124524672592264d31847182c689095a081c9e85264"
         },


### PR DESCRIPTION
Resolves #372

In the future, I guess squid-py will use Plecos to check if metadata complies with OEP-8, so this is just a temporary thing to prevent confusion about what "tags" should be. See issue #308 and https://github.com/oceanprotocol/oceandb-elasticsearch-driver/pull/19#issuecomment-496130090 