### PR TITLE
Begin overall metadata checksum with '0x'

### DIFF
--- a/squid_py/ddo/ddo.py
+++ b/squid_py/ddo/ddo.py
@@ -334,14 +334,15 @@ class DDO:
 
         :param did: DID, str
         :param metadata: conforming to the Metadata accepted by Ocean Protocol, dict
-        :return: hex str
+        :return: hex str, beginning with '0x'
         """
         files_checksum = ''
         for file in metadata['base']['files']:
             if 'checksum' in file:
                 files_checksum = files_checksum + file['checksum']
-        return hashlib.sha3_256((files_checksum +
-                                 metadata['base']['name'] +
-                                 metadata['base']['author'] +
-                                 metadata['base']['license'] +
-                                 did).encode('UTF-8')).hexdigest()
+        hashstr = hashlib.sha3_256((files_checksum +
+                                    metadata['base']['name'] +
+                                    metadata['base']['author'] +
+                                    metadata['base']['license'] +
+                                    did).encode('UTF-8')).hexdigest()
+        return '0x' + hashstr

--- a/squid_py/keeper/keeper.py
+++ b/squid_py/keeper/keeper.py
@@ -96,8 +96,10 @@ class Keeper(object):
 
         :param msg_hash:
         :param account: Account
-        :return:
+        :return: signature
         """
+        if msg_hash[:2] == '0x':
+            msg_hash = msg_hash[2:]
         return Web3Provider.get_web3().personal.sign(
             msg_hash, account.address, account.password
         )

--- a/squid_py/ocean/ocean_assets.py
+++ b/squid_py/ocean/ocean_assets.py
@@ -169,9 +169,11 @@ class OceanAssets:
             f'`Access` service initialize @{ddo.services[0].endpoints.service}.')
         response = None
         # register on-chain
+        # Remove '0x' from the start of metadata_copy['base']['checksum']
+        text_for_sha3 = metadata_copy['base']['checksum'][2:]
         registered_on_chain = self._keeper.did_registry.register(
             did,
-            checksum=Web3Provider.get_web3().sha3(text=metadata_copy['base']['checksum']),
+            checksum=Web3Provider.get_web3().sha3(text=text_for_sha3),
             url=ddo_service_endpoint,
             account=publisher_account,
             providers=providers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,9 +73,11 @@ def setup_agreements_enviroment():
 
     ddo = get_ddo_sample()
     ddo._did = DID.did()
+    # Remove '0x' from the start of ddo.metadata['base']['checksum']
+    text_for_sha3 = ddo.metadata['base']['checksum'][2:]
     keeper.did_registry.register(
         ddo.did,
-        checksum=Web3Provider.get_web3().sha3(text=ddo.metadata['base']['checksum']),
+        checksum=Web3Provider.get_web3().sha3(text=text_for_sha3),
         url='aquarius:5000',
         account=publisher_acc,
         providers=None

--- a/tests/resources/ddo/ddo_sa_sample.json
+++ b/tests/resources/ddo/ddo_sa_sample.json
@@ -228,7 +228,7 @@
           "inLanguage": "en",
           "tags": ["weather", "uk", "2011", "temperature", "humidity"],
           "price": 10,
-          "checksum": "38803b9e6f04fce3fba4b124524672592264d31847182c689095a081c9e85264"
+          "checksum": "0x38803b9e6f04fce3fba4b124524672592264d31847182c689095a081c9e85264"
         },
         "curation": {
           "rating": 0.93,

--- a/tests/resources/ddo/ddo_sample1.json
+++ b/tests/resources/ddo/ddo_sample1.json
@@ -126,7 +126,7 @@
           "inLanguage": "en",
           "tags": ["weather", "uk", "2011", "temperature", "humidity"],
           "price": 10,
-          "checksum": "38803b9e6f04fce3fba4b124524672592264d31847182c689095a081c9e85264"
+          "checksum": "0x38803b9e6f04fce3fba4b124524672592264d31847182c689095a081c9e85264"
         },
         "curation": {
           "rating": 0.93,

--- a/tests/resources/ddo/ddo_sample2.json
+++ b/tests/resources/ddo/ddo_sample2.json
@@ -86,7 +86,7 @@
           "inLanguage": "en",
           "tags": ["weather", "uk", "2011", "temperature", "humidity"],
           "price": 10,
-          "checksum": "38803b9e6f04fce3fba4b124524672592264d31847182c689095a081c9e85264"
+          "checksum": "0x38803b9e6f04fce3fba4b124524672592264d31847182c689095a081c9e85264"
         },
         "curation": {
           "rating": 0.93,


### PR DESCRIPTION
This pull request is one of the tasks to take care of issue https://github.com/oceanprotocol/ocean/issues/335

The main thing it does is change the overall checksum in the metadata to start with "0x". It doesn't change the file checksums because they are just inputs coming from elsewhere (i.e. not part of Ocean Protocol).

That overall checksum is used downstream in two ways:

1. It's signed to compute the "proof" section of the DDO.
1. It's hashed (again) to compute a second/different checksum that is used when registering the asset on-chain in the DID registry.

so I modified that downstream code to remove the "0x" in front, so the result is the same as it was before.